### PR TITLE
added NumFocus link to the footer

### DIFF
--- a/components/footer/index.js
+++ b/components/footer/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import Link from "next/link";
 import { navigation, NavItems } from '@components/header';
 import { StyledFooter } from '@components/footer/styled';
 
@@ -6,10 +7,14 @@ const Footer = (props) => (
   <StyledFooter>
     <StyledFooter.Wrapper>
       <StyledFooter.Section>
-        <img
-          src="https://nteract.github.io/assets/images/sponsor-numfocus.png"
-          alt="NumFocus"
-        />
+        <Link href="https://numfocus.org/">
+          <a target="_blank">
+            <img
+              src="https://nteract.github.io/assets/images/sponsor-numfocus.png"
+              alt="NumFocus"
+            />
+          </a>
+        </Link>
       </StyledFooter.Section>
       <StyledFooter.Section>
         <NavItems {...navigation.left} />


### PR DESCRIPTION
Added a link to https://numfocus.org/ on the NumFocus logo in the footer of the site.

The logo now appears slightly opaque until hovered over to match the styling of the other links.