### PR TITLE
Add Julia and C++ kernel information

### DIFF
--- a/components/kernels/c++.js
+++ b/components/kernels/c++.js
@@ -1,60 +1,38 @@
 // @flow
-import Layout from "@components/layout";
-import Link from "next/link";
-import React from "react";
-import Node from "@components/kernels/c++";
-import {
-  PageHeader,
-  PageHeaderLeft,
-  PageHeaderRight
-} from "@components/page-header";
+import * as React from "react";
+import Kernel from "./kernel";
+import SyntaxHighlighter from "react-syntax-highlighter";
+import { github } from "react-syntax-highlighter/styles/hljs";
+import { ContentSection } from "../content-section";
 
-export default class NodePage extends React.Component<*, *> {
-  render() {
-    let themeColor = "#2C1F39";
+const condaInstall = `conda create -n cling
+source activate cling
+conda install xeus-cling notebook -c QuantStack -c conda-forge
+python -m ipykernel install --user --name myenv --display-name "C++ (cling)"`;
 
-    return (
-      <Layout pageTitle=": connect with nteract" themeColor={themeColor}>
-        <PageHeader themeColor={themeColor}>
-          <PageHeaderLeft>
-            <h1>Kernels</h1>
-            <p>
-              Kernels connect your favorite languages to nteract projects for an
-              improved REPL experience. To date, there are over
-              <a href="https://github.com/jupyter/jupyter/wiki/Jupyter-kernels">
-                {" "}
-                100 community-developed kernels
-              </a>{" "}
-              available on GitHub.
-            </p>
-            <div className="buttons">
-              <Link href="/kernels/python">
-                <a className="button button-secondary">Python</a>
-              </Link>
-              <Link href="/kernels/node">
-                <a className="button button-secondary">Node.js</a>
-              </Link>
-              <Link href="/kernels/r">
-                <a className="button button-secondary">R</a>
-              </Link>
-              <Link href="/kernels/julia">
-                <a className="button button-secondary">Julia</a>
-              </Link>
-              <Link href="/kernels/c++">
-                <a className="button button-secondary active">C++</a>
-              </Link>
-            </div>
-          </PageHeaderLeft>
-          <PageHeaderRight>
-            <img
-              src="/static/kernels-terminal.png"
-              alt="Hydrogen"
-              className="cutoff-image"
-            />
-          </PageHeaderRight>
-        </PageHeader>
-        <Node />
-      </Layout>
-    );
-  }
-}
+export default () => (
+  <ContentSection>
+    <ContentSection.Pane full>
+      <Kernel
+        displayName="C++"
+        repository="https://github.com/QuantStack/xeus-cling"
+        installURL="https://github.com/QuantStack/xeus-cling#installation"
+        logo="https://upload.wikimedia.org/wikipedia/commons/thumb/1/18/ISO_C%2B%2B_Logo.svg/200px-ISO_C%2B%2B_Logo.svg.png"
+      >
+        <h3>Installation</h3>
+        <p>
+          The C++ kernel xeus-cling is installed with conda and added with
+          ipykernel to your list of kernels.
+        </p>
+        <div className="columns">
+          <div className="column">
+            <h4>Using conda</h4>
+            <SyntaxHighlighter language="zsh" style={github}>
+              {condaInstall}
+            </SyntaxHighlighter>
+          </div>
+        </div>
+      </Kernel>
+    </ContentSection.Pane>
+  </ContentSection>
+);

--- a/components/kernels/julia.js
+++ b/components/kernels/julia.js
@@ -1,60 +1,31 @@
 // @flow
-import Layout from "@components/layout";
-import Link from "next/link";
-import React from "react";
-import Python from "@components/kernels/julia";
-import {
-  PageHeader,
-  PageHeaderLeft,
-  PageHeaderRight
-} from "@components/page-header";
+import * as React from "react";
+import Kernel from "./kernel";
+import SyntaxHighlighter from "react-syntax-highlighter";
+import { github } from "react-syntax-highlighter/styles/hljs";
+import { ContentSection } from "../content-section";
 
-export default class PythonPage extends React.Component<*, *> {
-  render() {
-    let themeColor = "#2C1F39";
+const install = `Pkg.add("IJulia")`;
 
-    return (
-      <Layout pageTitle=": connect with nteract" themeColor={themeColor}>
-        <PageHeader themeColor={themeColor}>
-          <PageHeaderLeft>
-            <h1>Kernels</h1>
-            <p>
-              Kernels connect your favorite languages to nteract projects for an
-              improved REPL experience. To date, there are over
-              <a href="https://github.com/jupyter/jupyter/wiki/Jupyter-kernels">
-                {" "}
-                100 community-developed kernels
-              </a>{" "}
-              available on GitHub.
-            </p>
-            <div className="buttons">
-              <Link href="/kernels/python">
-                <a className="button button-secondary">Python</a>
-              </Link>
-              <Link href="/kernels/node">
-                <a className="button button-secondary">Node.js</a>
-              </Link>
-              <Link href="/kernels/r">
-                <a className="button button-secondary">R</a>
-              </Link>
-              <Link href="/kernels/julia">
-                <a className="button button-secondary active">Julia</a>
-              </Link>
-              <Link href="/kernels/c++">
-                <a className="button button-secondary">C++</a>
-              </Link>
-            </div>
-          </PageHeaderLeft>
-          <PageHeaderRight>
-            <img
-              src="/static/kernels-terminal.png"
-              alt="Hydrogen"
-              className="cutoff-image"
-            />
-          </PageHeaderRight>
-        </PageHeader>
-        <Python />
-      </Layout>
-    );
-  }
-}
+export default () => (
+  <ContentSection>
+    <ContentSection.Pane full>
+      <Kernel
+        displayName="Julia"
+        repository="https://github.com/JuliaLang/IJulia.jl"
+        installURL="https://irkernel.github.io/installation/"
+        logo="https://raw.githubusercontent.com/JuliaLang/IJulia.jl/master/deps/ijulialogo.png"
+      >
+        <h3>Installation</h3>
+        <div className="columns">
+          <div className="column">
+            <h4>Within Julia</h4>
+            <SyntaxHighlighter language="julia" style={github}>
+              {install}
+            </SyntaxHighlighter>
+          </div>
+        </div>
+      </Kernel>
+    </ContentSection.Pane>
+  </ContentSection>
+);

--- a/components/kernels/python.js
+++ b/components/kernels/python.js
@@ -7,19 +7,10 @@ import { github } from "react-syntax-highlighter/styles/hljs";
 import { ContentSection } from "../content-section";
 
 const pipInstall = `python -m pip install ipykernel virtualenv
-python -m ipykernel install
-python -m virtualenv myenv
-source myenv/bin/activate
-pip install ipykernel
-pip install -r requirements.txt
-python -m ipykernel install --user --name myenv --display-name "Python (myenv)"`;
+python -m ipykernel install`;
 
 const condaInstall = `conda install ipykernel
-python -m ipykernel install
-conda env create -f environment.yml
-source activate myenv
-conda install ipykernel
-python -m ipykernel install --user --name myenv --display-name "Python (myenv)"`;
+python -m ipykernel install`;
 
 export default () => (
   <ContentSection>

--- a/components/kernels/styled/index.js
+++ b/components/kernels/styled/index.js
@@ -28,7 +28,7 @@ export const KernelHeader = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: flex-end;
-  padding-bottom: ${spacing.unit};
+  padding-bottom: ${spacing.unit}px;
   border-bottom: 1px solid rgba(${colors.colorTextBase}, 0.15);
   margin-bottom: ${spacing.gutter};
   ${handheld(css`
@@ -40,9 +40,9 @@ export const KernelHeader = styled.div`
     display: flex;
     align-items: center;
     ${handheld(css`
-      margin-bottom: ${spacing.gutter};
+      margin-bottom: ${spacing.gutter}px;
     `)} ${LangLogo} {
-      margin-right: ${spacing.unit};
+      margin-right: ${spacing.unit}px;
       max-width: 48px;
     }
   }
@@ -53,12 +53,14 @@ export const KernelHeaderButtons = styled.div`
 `;
 
 export const KernelHeaderButton = styled.a`
+  color: ${colors.linkColor};
   border: 1px solid rgba(${colors.colorTextBase}, 0.15);
   background: white;
   box-shadow: ${effects.dropShadowLight};
   border-radius: 8px;
-  padding: ${spacing.unit};
+  padding: ${spacing.unit}px;
   display: block;
+  text-decoration: none;
   transition: ${animations.transition};
   :hover {
     transform: translateY(-4px);


### PR DESCRIPTION
Hi! First time contributor here (in fact, this is my first ever PR). I wanted to contribute to nteract and thought that the website would be a good place to start. While looking through the code I realised that instructions for C++ and Julia kernels had been added in #45, but in the current version the components are not displayed on the /kernels page. I've added them back in and cleaned up a duplicated `RenderContent` component. Furthermore, I fixed a bug in `/components/kernels/styled/index.js` where `px` strings weren't added to spacing variables in `styled-components` CSS-in-JS.