### PR TITLE
Update links in Julia kernel page and installation instructions

### DIFF
--- a/components/kernels/julia.js
+++ b/components/kernels/julia.js
@@ -5,8 +5,7 @@ import SyntaxHighlighter from "react-syntax-highlighter";
 import { github } from "react-syntax-highlighter/styles/hljs";
 import { ContentSection } from "../content-section";
 
-const install = `
-# From a Julia prompt
+const install = `# From a Julia prompt
 using Pkg
 Pkg.add("IJulia")`;
 
@@ -23,9 +22,10 @@ export default () => (
         <div className="columns">
           <div className="column">
             <p>
-              Install Julia to your system. https://julialang.org/downloads/
+              Install <a href="https://julialang.org/downloads/">Julia</a> to
+              your system.
             </p>
-            <h4>Within Julia</h4>
+            <h4>Within Julia, install IJulia kernel</h4>
             <SyntaxHighlighter language="julia" style={github}>
               {install}
             </SyntaxHighlighter>

--- a/components/kernels/julia.js
+++ b/components/kernels/julia.js
@@ -5,7 +5,10 @@ import SyntaxHighlighter from "react-syntax-highlighter";
 import { github } from "react-syntax-highlighter/styles/hljs";
 import { ContentSection } from "../content-section";
 
-const install = `Pkg.add("IJulia")`;
+const install = `
+# From a Julia prompt
+using Pkg
+Pkg.add("IJulia")`;
 
 export default () => (
   <ContentSection>
@@ -13,12 +16,15 @@ export default () => (
       <Kernel
         displayName="Julia"
         repository="https://github.com/JuliaLang/IJulia.jl"
-        installURL="https://irkernel.github.io/installation/"
+        installURL="https://github.com/JuliaLang/IJulia.jl#installation"
         logo="https://raw.githubusercontent.com/JuliaLang/IJulia.jl/master/deps/ijulialogo.png"
       >
         <h3>Installation</h3>
         <div className="columns">
           <div className="column">
+            <p>
+              Install Julia to your system. https://julialang.org/downloads/
+            </p>
             <h4>Within Julia</h4>
             <SyntaxHighlighter language="julia" style={github}>
               {install}


### PR DESCRIPTION
- update incorrect link that was directing to IR kernel
- add a bit more detail on the installation instruction