### PR TITLE
Add Feedback link to left nav

### DIFF
--- a/components/header/index.js
+++ b/components/header/index.js
@@ -22,6 +22,11 @@ const leftNav = {
       label: "About",
       href: "/about",
       prefetch: true
+    },
+    {
+      label: "Feedback",
+      href: "https://github.com/nteract/nteract/issues/new/choose",
+      target: "_blank"
     }
   ]
 };

--- a/components/navigation/navigation-left.js
+++ b/components/navigation/navigation-left.js
@@ -13,5 +13,12 @@ export default () => (
     <Link href="/about" as="/about">
       <a className="nav-item">About</a>
     </Link>
+    <a
+      href="https://github.com/nteract/nteract/issues/new/choose"
+      target="_blank"
+      className="nav-item"
+    >
+      Feedback
+    </a>
   </div>
 );


### PR DESCRIPTION
Provides a place for website visitors to submit feedback via GH issues. Not the most inclusive for folks without a GH account though so we might wanna figure out if there is a way for us to link a generic feedback form to our issue board.