### PR TITLE
Update page-header.js to specify where kernels are searched for

### DIFF
--- a/components/kernels/page-header.js
+++ b/components/kernels/page-header.js
@@ -7,7 +7,9 @@ export default themeColor => (
       <PageHeader.Title>Kernels</PageHeader.Title>
       <p>
         Kernels connect your favorite languages to nteract projects for an
-        improved REPL experience.
+        improved REPL experience. nteract looks for installed kernels in
+        your local python/pip or conda environment. More detailed instructions 
+        for various kernels can be found below.
       </p>
     </PageHeader.Left>
     <PageHeader.Right />


### PR DESCRIPTION
Pursuant to https://github.com/nteract/nteract/issues/5201 I would like to adjust the text on the kernels page. I put it into the header so it can be read for all kernels.