### PR TITLE
updated IJulia kernel update instructions

### DIFF
--- a/components/kernels/julia.js
+++ b/components/kernels/julia.js
@@ -12,6 +12,7 @@ julia> Pkg.add("IJulia")`;
 const updateKernel = `# From a Julia prompt
 julia> using Pkg
 julia> Pkg.update("IJulia")
+julia> using IJulia
 julia> IJulia.installkernel("Julia nteract")`;
 
 export default () => (


### PR DESCRIPTION
Adressed an issue that might confuse beginners:

Changed IJulia kernel update instructions because the current instruction leads to a 'not defined' error, since IJulia was not imported. 