### PR TITLE
Use REST API for fetching members on build

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "babel-plugin-styled-components": "2.0.7",
     "babel-plugin-transform-flow-strip-types": "6.22.0",
     "flow-bin": "0.84.0",
-    "graphql-request": "1.8.2",
     "lint-staged": "12.5.0",
     "prettier": "2.6.2"
   },


### PR DESCRIPTION
Avoid the dependency on a GitHub token for fetching members.

We only do this during build time so we don't have to worry as much about rate-limiting for these requests.