### PR TITLE
Add navigation links to blog pages

### DIFF
--- a/app/(blog)/blog/[slug]/page.tsx
+++ b/app/(blog)/blog/[slug]/page.tsx
@@ -112,13 +112,6 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
 
           <div className="flex flex-wrap items-center gap-6">
             <BlogTagList tags={post.tags} />
-            <Link
-              href="/blog"
-              className="inline-flex items-center gap-2 font-mono text-[11px] uppercase tracking-widest text-outline-variant transition-colors hover:text-on-surface"
-            >
-              <span aria-hidden="true">←</span>
-              All posts
-            </Link>
           </div>
         </header>
 
@@ -139,6 +132,17 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
         <Prose className="prose-invert mx-auto max-w-2xl">
           <Content />
         </Prose>
+
+        {/* Post footer */}
+        <div className="mx-auto mt-16 flex max-w-2xl items-center gap-4">
+          <Link
+            href="/blog"
+            className="font-mono text-[11px] uppercase tracking-widest text-[#a993d1] transition-colors hover:text-on-surface"
+          >
+            ← All posts
+          </Link>
+          <div className="h-px flex-grow bg-outline-variant/20" />
+        </div>
       </article>
     </div>
   );

--- a/app/(blog)/blog/page.tsx
+++ b/app/(blog)/blog/page.tsx
@@ -39,13 +39,20 @@ export default async function BlogPage() {
         {latest ? (
           <>
             <div className="mb-6 flex items-center gap-4">
+              <Link
+                href="/"
+                className="font-mono text-[11px] uppercase tracking-widest text-[#a993d1] transition-colors hover:text-on-surface"
+              >
+                ← Home
+              </Link>
+              <div className="h-px flex-grow bg-outline-variant/20" />
               <time
                 dateTime={latest.date}
                 className="font-mono text-xs uppercase tracking-widest text-secondary"
               >
                 {formatPostDate(latest.date)}
               </time>
-              <div className="h-px flex-grow bg-outline-variant/20" />
+              <div className="h-px w-4 bg-outline-variant/20" />
               <a
                 href={siteConfig.links.rss}
                 className="font-mono text-[11px] uppercase tracking-widest text-outline-variant transition-colors hover:text-on-surface"


### PR DESCRIPTION
## Summary
- Blog listing page (`/blog`): adds a "← Home" link in the date/RSS header row, linking back to the main site
- Blog post pages (`/blog/[slug]`): moves "← All posts" from the article header to the end of the post, so the reading flow isn't interrupted

## Test plan
- [ ] Visit `/blog` and verify "← HOME" appears left of the date, links to `/`
- [ ] Visit `/blog/nteract-2.0` and verify "← ALL POSTS" appears after the post content, links to `/blog`
- [ ] Check responsive layout at mobile widths