### PR TITLE
site: serve llms.txt and markdown blog siblings

### DIFF
--- a/app/(blog)/blog/[slug]/index.md/route.ts
+++ b/app/(blog)/blog/[slug]/index.md/route.ts
@@ -1,0 +1,31 @@
+import { formatPostAsMarkdown, getAllSlugs, getPostBySlug } from "@/lib/blog";
+
+export const dynamic = "force-static";
+export const dynamicParams = false;
+
+const isDev = process.env.NODE_ENV === "development";
+
+export async function generateStaticParams() {
+  const slugs = await getAllSlugs({ includeUnpublished: isDev });
+  return slugs.map((slug) => ({ slug }));
+}
+
+type RouteContext = {
+  params: Promise<{ slug: string }>;
+};
+
+export async function GET(_request: Request, { params }: RouteContext) {
+  const { slug } = await params;
+  const post = await getPostBySlug(slug, { includeUnpublished: isDev });
+
+  if (!post) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  return new Response(formatPostAsMarkdown(post), {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400",
+    },
+  });
+}

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -1,0 +1,29 @@
+import { getAllPosts } from "@/lib/blog";
+import { absoluteUrl, siteConfig } from "@/lib/site";
+
+export const dynamic = "force-static";
+
+export async function GET() {
+  const posts = await getAllPosts();
+
+  const lines = [
+    `# ${siteConfig.name}`,
+    "",
+    `> ${siteConfig.description}`,
+    "",
+    "## Blog",
+    "",
+    ...posts.map(
+      (post) =>
+        `- [${post.title}](${absoluteUrl(`/blog/${post.slug}/index.md`)}): ${post.description}`,
+    ),
+    "",
+  ];
+
+  return new Response(lines.join("\n"), {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400",
+    },
+  });
+}

--- a/lib/blog.test.ts
+++ b/lib/blog.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import { getAllPosts, getAllSlugs, getPostBySlug } from "@/lib/blog";
+import { formatPostAsMarkdown, getAllPosts, getAllSlugs, getPostBySlug } from "@/lib/blog";
 
 describe("blog content utilities", () => {
   it("returns published posts in reverse chronological order by default", async () => {
@@ -24,5 +24,29 @@ describe("blog content utilities", () => {
 
     expect(post).not.toBeNull();
     expect(post?.published).toBe(true);
+  });
+
+  it("formats a post as markdown with title, blockquote, metadata, link, and body", async () => {
+    const post = await getPostBySlug("security");
+    expect(post).not.toBeNull();
+
+    const md = formatPostAsMarkdown(post!);
+
+    expect(md.startsWith("# Securing Notebooks\n")).toBe(true);
+    expect(md).toContain("> Remote Code Execution is the Feature. Lock it down.");
+    expect(md).toMatch(/\*Published April 7, 2026 \u00b7 tags: security, architecture\*/);
+    expect(md).toContain("[Original post](https://nteract.io/blog/security)");
+    expect(md).toContain("\n---\n");
+    expect(md).toContain(post!.content.trim());
+  });
+
+  it("omits the tags segment when a post has no tags", async () => {
+    const post = await getPostBySlug("security");
+    expect(post).not.toBeNull();
+
+    const md = formatPostAsMarkdown({ ...post!, tags: [] });
+
+    expect(md).toMatch(/\*Published April 7, 2026\*/);
+    expect(md).not.toContain("tags:");
   });
 });

--- a/lib/blog.ts
+++ b/lib/blog.ts
@@ -3,6 +3,8 @@ import path from "node:path";
 
 import matter from "gray-matter";
 
+import { absoluteUrl } from "@/lib/site";
+
 const BLOG_DIRECTORY = path.join(process.cwd(), "content/blog");
 
 export type BlogPostFrontmatter = {
@@ -184,8 +186,31 @@ const postDateFormatter = new Intl.DateTimeFormat("en", {
   month: "long",
   day: "numeric",
   year: "numeric",
+  timeZone: "UTC",
 });
 
 export function formatPostDate(value: string) {
   return postDateFormatter.format(new Date(value));
+}
+
+export function formatPostAsMarkdown(post: BlogPost): string {
+  const meta =
+    post.tags.length > 0
+      ? `*Published ${formatPostDate(post.date)} \u00b7 tags: ${post.tags.join(", ")}*`
+      : `*Published ${formatPostDate(post.date)}*`;
+
+  return [
+    `# ${post.title}`,
+    "",
+    `> ${post.description}`,
+    "",
+    meta,
+    "",
+    `[Original post](${absoluteUrl(`/blog/${post.slug}`)})`,
+    "",
+    "---",
+    "",
+    post.content.trim(),
+    "",
+  ].join("\n");
 }


### PR DESCRIPTION
## Summary

- `/llms.txt` indexes published blog posts per the [llmstxt.org](https://llmstxt.org) convention.
- `/blog/<slug>/index.md` returns each post as plain markdown. Frontmatter is rewritten as a small human-readable header.
- Both routes are `force-static`. They ship as files in the build output. No runtime cost beyond CDN delivery.

The original target was `/blog/<slug>.md`. Next.js 15.5.15 doesn't extract dynamic params correctly when the segment includes a literal `.md` suffix, so the markdown sibling lives one level deeper as `/<slug>/index.md`. Same shape, working routing.

Drive-by: `formatPostDate` now formats in UTC. Blog post dates in frontmatter are date-only and parse as UTC midnight, so without this they'd render a day early in any timezone west of UTC.

## Test plan

- [x] `pnpm test` passes (covers the new `formatPostAsMarkdown` helper)
- [x] `pnpm build` succeeds, both `/llms.txt` and per-slug `index.md` routes show up as statically generated
- [ ] After deploy: `curl https://nteract.io/llms.txt` returns the index
- [ ] After deploy: `curl https://nteract.io/blog/security/index.md` returns the post body