### PR TITLE
site: vary on Accept via vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,16 @@
+{
+  "headers": [
+    {
+      "source": "/",
+      "headers": [{ "key": "Vary", "value": "Accept" }]
+    },
+    {
+      "source": "/blog",
+      "headers": [{ "key": "Vary", "value": "Accept" }]
+    },
+    {
+      "source": "/blog/:slug",
+      "headers": [{ "key": "Vary", "value": "Accept" }]
+    }
+  ]
+}


### PR DESCRIPTION
## What

Adds a `vercel.json` that sets `Vary: Accept` on `/`, `/blog`, and `/blog/:slug`.

## Why

#623 added Accept-header negotiation in middleware. Middleware sets `Vary: Accept` on its response, but Next.js's prerender cache strips middleware headers on the way out, both locally and on Vercel preview (verified). Vercel's platform-level header config applies after Next's cache, so the header lands on every matched response.

The risk this plugs: a downstream cache (browser, corporate proxy) caches a markdown response under \`/blog/security\` and serves it back to a follow-up browser request, or vice versa. Vercel's own edge cache is safe because middleware runs before cache lookup and the rewritten URL is the cache key. This is purely about clients between the user and Vercel.

## Test plan

- [ ] Vercel preview: \`curl -I https://<preview>/blog/security\` shows \`Vary\` includes \`Accept\`
- [ ] Vercel preview: same on \`/\` and \`/blog\`
- [ ] Negotiation still works (browser -> HTML, \`Accept: text/markdown\` -> markdown)