### PR TITLE
Add /telemetry/llms.txt route

### DIFF
--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -37,7 +37,7 @@ export async function GET() {
     "",
     downloadsLine,
     `- [Source on GitHub](${siteConfig.links.github})`,
-    `- [Telemetry policy](${siteConfig.url}/telemetry): what nteract sends, what it never sends, and how to opt out.`,
+    `- [Telemetry policy](${absoluteUrl("/telemetry/llms.txt")}): what nteract sends, what it never sends, and how to opt out.`,
     "",
     "## Blog",
     "",

--- a/app/telemetry/llms.txt/route.ts
+++ b/app/telemetry/llms.txt/route.ts
@@ -7,7 +7,7 @@ export async function GET() {
 
   return new Response(md, {
     headers: {
-      "Content-Type": "text/markdown; charset=utf-8",
+      "Content-Type": "text/plain; charset=utf-8",
       "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400",
     },
   });

--- a/lib/telemetry-md.ts
+++ b/lib/telemetry-md.ts
@@ -1,0 +1,22 @@
+import { _markdown } from "@/content/telemetry.mdx";
+import { renderPlaceholder } from "fumadocs-core/mdx-plugins/remark-llms.runtime";
+import { FIELDS } from "@/lib/telemetry-data";
+
+/**
+ * Resolve the remarkLLMs markdown export from telemetry.mdx,
+ * replacing component placeholders with their static markdown form.
+ *
+ * Shared by /telemetry/raw.md and /telemetry/llms.txt routes.
+ */
+export function resolveTelemetryMarkdown(): Promise<string> {
+  return renderPlaceholder(_markdown, {
+    PingPreview() {
+      const lines = ["```", "{"];
+      for (const f of FIELDS) {
+        lines.push(`  "${f.name}": "${f.example}",`);
+      }
+      lines.push("}", "```");
+      return lines.join("\n");
+    },
+  });
+}


### PR DESCRIPTION
Adds `/telemetry/llms.txt` serving the same remarkLLMs-generated markdown as `raw.md`, with `Content-Type: text/plain`.

Extracts the shared placeholder resolution into `lib/telemetry-md.ts` so both routes are one-liners. Updates the top-level `llms.txt` to link directly to `/telemetry/llms.txt`.

_PR submitted by @rgbkrk's agent Quill, via Zed_