### PR TITLE
Restore interactive components in telemetry MDX

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -286,6 +286,13 @@ body {
     font-family: var(--font-page-serif), Georgia, serif;
 }
 
+.cream-page h1 {
+    font-size: 44px;
+    line-height: 1.05;
+    font-weight: 400;
+    margin-bottom: 2rem;
+}
+
 .cream-page a {
     color: var(--accent);
     text-decoration: underline;
@@ -330,55 +337,4 @@ body {
 .cream-page thead th:first-child,
 .cream-page tbody td:first-child {
     font-family: var(--font-mono), "JetBrains Mono", monospace;
-}
-
-/* ──────────────────────────────────────
-   Telemetry article prose rhythm.
-   Applied via className="prose-telemetry"
-   on the <article> wrapping MDX content.
-   ────────────────────────────────────── */
-.prose-telemetry {
-    font-size: 17px;
-    line-height: 1.7;
-    color: var(--ink);
-}
-
-.prose-telemetry > h1 {
-    font-size: 44px;
-    line-height: 1.05;
-    font-weight: 400;
-    margin-bottom: 2rem;
-}
-
-.prose-telemetry > h2 {
-    font-size: 1.5rem;
-    font-weight: 600;
-    margin-top: 3rem;
-    margin-bottom: 1rem;
-}
-
-.prose-telemetry > h3 {
-    font-size: 1.125rem;
-    font-weight: 600;
-    margin-top: 1.5rem;
-    margin-bottom: 0.5rem;
-}
-
-.prose-telemetry > p {
-    margin-bottom: 1.25rem;
-}
-
-.prose-telemetry > ul {
-    list-style: disc;
-    padding-left: 1.25rem;
-    margin-bottom: 1.25rem;
-}
-
-.prose-telemetry > ul > li {
-    margin-bottom: 0.5rem;
-}
-
-.prose-telemetry > table {
-    margin-top: 1rem;
-    margin-bottom: 1.5rem;
 }

--- a/app/telemetry/page.tsx
+++ b/app/telemetry/page.tsx
@@ -5,8 +5,20 @@ import Content from "@/content/telemetry.mdx";
 export default function TelemetryPage() {
   return (
     <PageShell>
-      <article className="max-w-[62ch] mx-auto prose-telemetry">
-        <Content />
+      <article className="max-w-[62ch] mx-auto">
+        <div
+          className="text-[11px] tracking-[0.22em] uppercase mb-6"
+          style={{ color: "var(--accent)" }}
+        >
+          § Telemetry
+        </div>
+
+        <div
+          className="space-y-5 text-[17px] leading-8"
+          style={{ color: "var(--ink)" }}
+        >
+          <Content />
+        </div>
       </article>
     </PageShell>
   );

--- a/components/mdx-components.tsx
+++ b/components/mdx-components.tsx
@@ -13,7 +13,10 @@ import { Peekaboo } from "@/components/blog/peekaboo";
 import { IframeIsolationDiagram } from "@/components/blog/iframe-isolation-diagram";
 import { SocketDiagram } from "@/components/blog/socket-diagram";
 import { TauriComparison } from "@/components/blog/tauri-comparison";
+import { OptOut } from "@/components/telemetry/opt-out";
 import { PingPreview } from "@/components/telemetry/ping-preview";
+import { Receipt } from "@/components/telemetry/receipt";
+import { Rights } from "@/components/telemetry/rights";
 import { cn } from "@/lib/utils";
 
 function MdxLink({
@@ -118,7 +121,10 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
     IframeIsolationDiagram,
     SocketDiagram,
     TauriComparison,
+    OptOut,
     PingPreview,
+    Receipt,
+    Rights,
     ...components,
   };
 }

--- a/components/telemetry/opt-out.tsx
+++ b/components/telemetry/opt-out.tsx
@@ -1,0 +1,29 @@
+import { renderInlineCode } from "@/lib/inline-code";
+import { OPT_OUT_PATHS } from "@/lib/telemetry-data";
+
+export function OptOut() {
+  return (
+    <section className="mt-12">
+      <h2
+        className="text-2xl font-semibold mb-4"
+        style={{ color: "var(--ink)" }}
+      >
+        How to opt out
+      </h2>
+      <ul
+        className="space-y-3 text-[16px] leading-7"
+        style={{ color: "var(--ink)" }}
+      >
+        {OPT_OUT_PATHS.inApp.map((p) => (
+          <li key={p.label}>
+            <strong>{p.label}.</strong> {renderInlineCode(p.description)}
+          </li>
+        ))}
+      </ul>
+      <p className="mt-4 text-[13px]" style={{ color: "var(--muted)" }}>
+        For locked-down deployments and CI images:{" "}
+        {renderInlineCode(OPT_OUT_PATHS.envVar)}
+      </p>
+    </section>
+  );
+}

--- a/content/telemetry.mdx
+++ b/content/telemetry.mdx
@@ -2,76 +2,17 @@
 
 nteract is maintained under [NumFOCUS](https://numfocus.org/), a non-profit. We don't sell your data. We never will.
 
-One anonymous daily heartbeat gives us insight into usage and helps us improve nteract.
+One anonymous daily heartbeat tells funders that real people are using nteract. The ping is evidence of use, not funding.
 
 <PingPreview />
 
 If you'd rather not, flip it off. No penalty. No degraded features.
 
-## Your rights
+<Rights />
 
-### Access
+<OptOut />
 
-Open **Settings → Privacy** to see your install ID, last ping times, and current setting.
-
-### Rectify
-
-There's nothing to rectify. The six fields are facts about your build, not profile data.
-
-### Erase
-
-Rotate your install ID from **Settings → Privacy**. Old rows become unlinkable and age out at 400 days. To delete them immediately, call the server-side erasure endpoint (`DELETE /v1/install/{install_id}`) or email [privacy@nteract.io](mailto:privacy@nteract.io) with your install ID.
-
-### Object / withdraw
-
-Flip the setting off, any time. No penalty, no features lost.
-
-## How to opt out
-
-- **Onboarding choice.** Press "Opt out of metrics, continue" on the final onboarding screen.
-- **Settings → Privacy.** Flip the telemetry switch off any time. Rotate your install ID or request erasure from here too.
-- **CLI.** Run `runt config telemetry disable`. Check status with `runt config telemetry status`.
-
-For locked-down deployments and CI images: set `NTERACT_TELEMETRY_DISABLE=1`.
-
-## Exactly what's sent
-
-| Field | Example | Description |
-|---|---|---|
-| install_id | `550e8400-e29b-41d4-a716-446655440000` | Opaque UUIDv4 generated on first run. Not derived from any identifying data. |
-| source | `app` | Which process sent the ping. One of `app`, `daemon`, or `mcp`. |
-| version | `2.2.1` | Release version of the build that sent the ping. |
-| channel | `nightly` | Release channel: `stable` or `nightly`. |
-| platform | `macos` | Operating system family: `macos`, `linux`, or `windows`. |
-| arch | `arm64` | CPU architecture: `arm64` or `x86_64`. |
-
-## What is never sent or stored
-
-- Hostname, username, home directory, or any filesystem path.
-- Notebook contents, cell outputs, kernel names, or environment details.
-- Dependency names or versions (Python, Node, R, system packages).
-- Hardware identifiers (MAC address, serial number, disk UUID).
-- Client IP address at rest. Cloudflare observes it briefly for rate limiting; the database does not store it.
-- User-Agent or any HTTP header beyond Content-Type.
-
-## When a ping is suppressed
-
-| Gate | Trigger |
-|---|---|
-| Dev mode | `RUNTIMED_DEV=1` or `RUNTIMED_WORKSPACE_PATH` is set |
-| CI | `CI` environment variable is set |
-| Kill switch | `NTERACT_TELEMETRY_DISABLE` environment variable is set |
-| Disabled | `telemetry_enabled = false` in settings |
-| Consent not recorded | `telemetry_consent_recorded = false` (user has not pressed either onboarding button) |
-| Not onboarded | `onboarding_completed = false` (fresh install before first-run screen) |
-| Unsupported host | Platform or architecture not in the server's enum |
-| Throttled | Last ping for this source was less than 20 hours ago |
-
-## Retention and schema evolution
-
-- **Raw pings**: kept for 400 days, then deleted by a nightly cleanup job.
-- **Daily aggregate counts**: kept indefinitely. No `install_id`; just counts grouped by `day`, `source`, `version`, `channel`, `platform`, `arch`.
-- New fields may be added over time (additive only). Any field removal is a breaking change that gets a new route version (`/v2/ping`).
+<Receipt />
 
 ## Sponsored project note
 

--- a/lib/telemetry-md.ts
+++ b/lib/telemetry-md.ts
@@ -1,6 +1,13 @@
 import { _markdown } from "@/content/telemetry.mdx";
 import { renderPlaceholder } from "fumadocs-core/mdx-plugins/remark-llms.runtime";
-import { FIELDS } from "@/lib/telemetry-data";
+import {
+  EMISSION_GATES,
+  ERASE_ENDPOINT_SHAPE,
+  FIELDS,
+  NEVER_SENT,
+  OPT_OUT_PATHS,
+  RETENTION,
+} from "@/lib/telemetry-data";
 
 /**
  * Resolve the remarkLLMs markdown export from telemetry.mdx,
@@ -16,6 +23,76 @@ export function resolveTelemetryMarkdown(): Promise<string> {
         lines.push(`  "${f.name}": "${f.example}",`);
       }
       lines.push("}", "```");
+      return lines.join("\n");
+    },
+
+    Rights() {
+      const lines = [
+        "## Your rights",
+        "",
+        "### Access",
+        "",
+        "Open **Settings → Privacy** to see your install ID, last ping times, and current setting.",
+        "",
+        "### Rectify",
+        "",
+        "There's nothing to rectify. The six fields are facts about your build, not profile data.",
+        "",
+        "### Erase",
+        "",
+        `Rotate your install ID from **Settings → Privacy**. Old rows become unlinkable and age out at ${RETENTION.rawPingDays} days. To delete them immediately, call the server-side erasure endpoint (\`${ERASE_ENDPOINT_SHAPE}\`) or email [privacy@nteract.io](mailto:privacy@nteract.io) with your install ID.`,
+        "",
+        "### Object / withdraw",
+        "",
+        "Flip the setting off, any time. No penalty, no features lost.",
+      ];
+      return lines.join("\n");
+    },
+
+    OptOut() {
+      const lines = [
+        "## How to opt out",
+        "",
+        ...OPT_OUT_PATHS.inApp.map((p) => `- **${p.label}.** ${p.description}`),
+        "",
+        `For locked-down deployments and CI images: ${OPT_OUT_PATHS.envVar}`,
+      ];
+      return lines.join("\n");
+    },
+
+    Receipt() {
+      const lines: string[] = [];
+
+      // Fields table
+      lines.push("## Exactly what's sent", "");
+      lines.push("| Field | Example | Description |", "|---|---|---|");
+      for (const f of FIELDS) {
+        lines.push(`| ${f.name} | \`${f.example}\` | ${f.description} |`);
+      }
+
+      // Never sent
+      lines.push("", "## What is never sent or stored", "");
+      for (const n of NEVER_SENT) lines.push(`- ${n}`);
+
+      // Emission gates
+      lines.push("", "## When a ping is suppressed", "");
+      lines.push("| Gate | Trigger |", "|---|---|");
+      for (const g of EMISSION_GATES) {
+        lines.push(`| ${g.name} | ${g.trigger} |`);
+      }
+
+      // Retention
+      lines.push("", "## Retention and schema evolution", "");
+      lines.push(
+        `- **Raw pings**: kept for ${RETENTION.rawPingDays} days, then deleted by a nightly cleanup job.`,
+      );
+      lines.push(
+        `- **Daily aggregate counts**: kept ${RETENTION.aggregatesKept}. No \`install_id\`; just counts grouped by ${RETENTION.rollupKeys.map((k) => "`" + k + "`").join(", ")}.`,
+      );
+      lines.push(
+        "- New fields may be added over time (additive only). Any field removal is a breaking change that gets a new route version (`/v2/ping`).",
+      );
+
       return lines.join("\n");
     },
   });

--- a/next.config.ts
+++ b/next.config.ts
@@ -15,7 +15,7 @@ const withMDX = createMDX({
       [
         remarkLLMs,
         {
-          mdxAsPlaceholder: ["PingPreview"],
+          mdxAsPlaceholder: ["PingPreview", "Rights", "OptOut", "Receipt"],
         },
       ],
     ],


### PR DESCRIPTION
The MDX conversion flattened the telemetry page to plain markdown sections, losing the expandable accordions and styled components. This brings them back.

`content/telemetry.mdx` now uses `<Rights />`, `<Receipt />`, `<PingPreview />`, and a new `<OptOut />` component inline. The components render the original cream-page styled UI with expandable `<details>` sections. remarkLLMs placeholders resolve each component to its markdown equivalent at build time — so `raw.md` and `llms.txt` still get clean markdown output.

**Added**
- `components/telemetry/opt-out.tsx` — opt-out section pulled from `OPT_OUT_PATHS`
- Placeholder renderers for Rights, OptOut, Receipt in `lib/telemetry-md.ts`
- `.cream-page h1` sizing in CSS

**Changed**
- `content/telemetry.mdx` — components for data-driven sections, plain markdown for prose
- `app/telemetry/page.tsx` — `§ Telemetry` label restored
- `next.config.ts` — all four components in `mdxAsPlaceholder`

**Removed**
- Unused `.prose-telemetry` CSS class

_PR submitted by @rgbkrk's agent Quill, via Zed_