### PR TITLE
Generate blog raw.md from remarkLLMs

### DIFF
--- a/app/(blog)/blog/[slug]/raw.md/route.ts
+++ b/app/(blog)/blog/[slug]/raw.md/route.ts
@@ -1,4 +1,7 @@
-import { formatPostAsMarkdown, getAllSlugs, getPostBySlug } from "@/lib/blog";
+import { renderPlaceholder } from "fumadocs-core/mdx-plugins/remark-llms.runtime";
+
+import { getAllSlugs, getPostBySlug } from "@/lib/blog";
+import { resolveBlogPlaceholders } from "@/lib/blog-md";
 
 export const dynamic = "force-static";
 export const dynamicParams = false;
@@ -22,7 +25,11 @@ export async function GET(_request: Request, { params }: RouteContext) {
     return new Response("Not found", { status: 404 });
   }
 
-  return new Response(formatPostAsMarkdown(post), {
+  const { _markdown } = await import(`@/content/blog/${slug}.mdx`);
+
+  const md = await renderPlaceholder(_markdown, resolveBlogPlaceholders);
+
+  return new Response(md, {
     headers: {
       "Content-Type": "text/markdown; charset=utf-8",
       "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400",

--- a/lib/blog-md.ts
+++ b/lib/blog-md.ts
@@ -1,0 +1,31 @@
+import type { PlaceholderData } from "fumadocs-core/mdx-plugins/remark-llms.runtime";
+
+/**
+ * Placeholder renderers for blog MDX components.
+ *
+ * Used by the /blog/[slug]/raw.md route to resolve remarkLLMs
+ * placeholders into plain markdown at build time.
+ */
+export const resolveBlogPlaceholders: Record<
+  string,
+  (data: PlaceholderData) => string
+> = {
+  Kbd({ children }) {
+    return `\`${children}\``;
+  },
+
+  BlogCTA() {
+    return [
+      "---",
+      "",
+      "[Download nteract](https://github.com/nteract/desktop/releases) · [Star on GitHub](https://github.com/nteract/desktop)",
+    ].join("\n");
+  },
+
+  BlogInlineCTA({ attributes, children }) {
+    const href = (attributes.href as string) ?? "";
+    const lead = (attributes.lead as string) ?? "";
+    const prefix = lead ? `${lead} ` : "";
+    return `${prefix}[${children}](${href})`;
+  },
+};

--- a/next.config.ts
+++ b/next.config.ts
@@ -15,7 +15,36 @@ const withMDX = createMDX({
       [
         remarkLLMs,
         {
-          mdxAsPlaceholder: ["PingPreview", "Rights", "OptOut", "Receipt"],
+          mdxAsPlaceholder: [
+            "PingPreview",
+            "Rights",
+            "OptOut",
+            "Receipt",
+            "Kbd",
+            "BlogCTA",
+            "BlogInlineCTA",
+          ],
+          // Annotate non-placeholder nodes so the stringifier strips them cleanly.
+          // node.data._stringify is checked after this callback — { text: '' }
+          // suppresses the node, 'children-only' keeps children and drops the wrapper.
+          stringify(node: {
+            type: string;
+            name?: string;
+            children?: unknown[];
+            data?: Record<string, unknown>;
+          }) {
+            if (
+              node.type === "mdxJsxFlowElement" ||
+              node.type === "mdxJsxTextElement"
+            ) {
+              if (node.children && node.children.length > 0) {
+                node.data = { ...node.data, _stringify: "children-only" };
+              } else {
+                node.data = { ...node.data, _stringify: { text: "" } };
+              }
+              return;
+            }
+          },
         },
       ],
     ],


### PR DESCRIPTION
Blog `raw.md` routes now use the `_markdown` export from compiled MDX instead of raw gray-matter source. Components are resolved to clean markdown via `renderPlaceholder()`.

Before: raw MDX source with `<LightboxImage>`, `<EnvPicker>`, `<video>` tags still in the output.

After: clean markdown. JSX stripped via `node.data._stringify` annotations in the remarkLLMs `stringify` callback.

Component handling:
- `Kbd` → backtick-wrapped text
- `BlogCTA` → download + GitHub links
- `BlogInlineCTA` → markdown link
- Everything else (video, div, diagrams, images) → children-only for wrappers, dropped for self-closing

Frontmatter stays at the top of the output as useful context.

_PR submitted by @rgbkrk's agent Quill, via Zed_