### PR TITLE
refactor(llms-txt): every MDX component owns its markdown view

### DIFF
--- a/app/telemetry/llms.txt/route.ts
+++ b/app/telemetry/llms.txt/route.ts
@@ -1,9 +1,12 @@
-import { resolveTelemetryMarkdown } from "@/lib/telemetry-md";
+import { renderPlaceholder } from "fumadocs-core/mdx-plugins/remark-llms.runtime";
+
+import { _markdown } from "@/content/telemetry.mdx";
+import { resolveTelemetryPlaceholders } from "@/lib/telemetry-md";
 
 export const dynamic = "force-static";
 
 export async function GET() {
-  const md = await resolveTelemetryMarkdown();
+  const md = await renderPlaceholder(_markdown, resolveTelemetryPlaceholders);
 
   return new Response(md, {
     headers: {

--- a/components/blog/cta.md.ts
+++ b/components/blog/cta.md.ts
@@ -1,0 +1,14 @@
+import type { PlaceholderData } from "fumadocs-core/mdx-plugins/remark-llms.runtime";
+
+/**
+ * Sibling markdown view of `<BlogCTA />`. Lives in a non-client file
+ * so the server-side llms.txt resolver can call it. (Static methods
+ * on a `"use client"` component are unreachable from server code
+ * because the import becomes a client reference.)
+ */
+export const blogCtaToMarkdown = (_data: PlaceholderData): string =>
+  [
+    "---",
+    "",
+    "[Download nteract](https://github.com/nteract/desktop/releases) · [Star on GitHub](https://github.com/nteract/desktop)",
+  ].join("\n");

--- a/components/blog/inline-cta.tsx
+++ b/components/blog/inline-cta.tsx
@@ -1,3 +1,4 @@
+import type { PlaceholderData } from "fumadocs-core/mdx-plugins/remark-llms.runtime";
 import type { ReactNode } from "react";
 
 type BlogInlineCTAProps = {
@@ -32,3 +33,10 @@ export function BlogInlineCTA({ href, children, lead }: BlogInlineCTAProps) {
     </div>
   );
 }
+
+BlogInlineCTA.toMarkdown = (data: PlaceholderData): string => {
+  const href = (data.attributes.href as string) ?? "";
+  const lead = (data.attributes.lead as string) ?? "";
+  const prefix = lead ? `${lead} ` : "";
+  return `${prefix}[${data.children}](${href})`;
+};

--- a/components/kbd.md.ts
+++ b/components/kbd.md.ts
@@ -1,0 +1,10 @@
+import type { PlaceholderData } from "fumadocs-core/mdx-plugins/remark-llms.runtime";
+
+/**
+ * Sibling markdown view of `<Kbd>`. Lives in a non-client file so the
+ * server-side llms.txt resolver can call it. (Static methods on a
+ * `"use client"` component are unreachable from server code because
+ * the import becomes a client reference.)
+ */
+export const kbdToMarkdown = (data: PlaceholderData): string =>
+  `\`${data.children}\``;

--- a/components/telemetry/opt-out.tsx
+++ b/components/telemetry/opt-out.tsx
@@ -1,3 +1,5 @@
+import type { PlaceholderData } from "fumadocs-core/mdx-plugins/remark-llms.runtime";
+
 import { renderInlineCode } from "@/lib/inline-code";
 import { OPT_OUT_PATHS } from "@/lib/telemetry-data";
 
@@ -27,3 +29,15 @@ export function OptOut() {
     </section>
   );
 }
+
+OptOut.toMarkdown = (_data: PlaceholderData): string => {
+  const lines = ["## How to opt out", ""];
+  for (const p of OPT_OUT_PATHS.inApp) {
+    lines.push(`- **${p.label}.** ${p.description}`);
+  }
+  lines.push(
+    "",
+    `For locked-down deployments and CI images: ${OPT_OUT_PATHS.envVar}`,
+  );
+  return lines.join("\n");
+};

--- a/components/telemetry/ping-preview.md.ts
+++ b/components/telemetry/ping-preview.md.ts
@@ -1,0 +1,18 @@
+import type { PlaceholderData } from "fumadocs-core/mdx-plugins/remark-llms.runtime";
+
+import { FIELDS } from "@/lib/telemetry-data";
+
+/**
+ * Sibling markdown view of `<PingPreview />`. Lives in a non-client
+ * file so the server-side llms.txt resolver can call it directly.
+ * (Static methods on a `"use client"` component are unreachable from
+ * server code because the import becomes a client reference.)
+ */
+export const pingPreviewToMarkdown = (_data: PlaceholderData): string => {
+  const lines = ["```", "{"];
+  for (const f of FIELDS) {
+    lines.push(`  "${f.name}": "${f.example}",`);
+  }
+  lines.push("}", "```");
+  return lines.join("\n");
+};

--- a/components/telemetry/receipt.tsx
+++ b/components/telemetry/receipt.tsx
@@ -1,3 +1,5 @@
+import type { PlaceholderData } from "fumadocs-core/mdx-plugins/remark-llms.runtime";
+
 import { renderInlineCode } from "@/lib/inline-code";
 import {
   EMISSION_GATES,
@@ -114,3 +116,35 @@ export function Receipt() {
     </div>
   );
 }
+
+Receipt.toMarkdown = (_data: PlaceholderData): string => {
+  const lines: string[] = [];
+
+  lines.push("## Exactly what's sent", "");
+  lines.push("| Field | Example | Description |", "|---|---|---|");
+  for (const f of FIELDS) {
+    lines.push(`| ${f.name} | \`${f.example}\` | ${f.description} |`);
+  }
+
+  lines.push("", "## What is never sent or stored", "");
+  for (const n of NEVER_SENT) lines.push(`- ${n}`);
+
+  lines.push("", "## When a ping is suppressed", "");
+  lines.push("| Gate | Trigger |", "|---|---|");
+  for (const g of EMISSION_GATES) {
+    lines.push(`| ${g.name} | ${g.trigger} |`);
+  }
+
+  lines.push("", "## Retention and schema evolution", "");
+  lines.push(
+    `- **Raw pings**: kept for ${RETENTION.rawPingDays} days, then deleted by a nightly cleanup job.`,
+  );
+  lines.push(
+    `- **Daily aggregate counts**: kept ${RETENTION.aggregatesKept}. No \`install_id\`; just counts grouped by ${RETENTION.rollupKeys.map((k) => "`" + k + "`").join(", ")}.`,
+  );
+  lines.push(
+    "- New fields may be added over time (additive only). Any field removal is a breaking change that gets a new route version (`/v2/ping`).",
+  );
+
+  return lines.join("\n");
+};

--- a/components/telemetry/rights.tsx
+++ b/components/telemetry/rights.tsx
@@ -1,11 +1,14 @@
+import type { PlaceholderData } from "fumadocs-core/mdx-plugins/remark-llms.runtime";
+
 import { ERASE_ENDPOINT_SHAPE, RETENTION } from "@/lib/telemetry-data";
 
-type Right = {
+type RightEntry = {
   title: string;
   body: React.ReactNode;
+  bodyMarkdown: string;
 };
 
-const RIGHTS: Right[] = [
+const RIGHTS: RightEntry[] = [
   {
     title: "Access",
     body: (
@@ -14,6 +17,8 @@ const RIGHTS: Right[] = [
         ping times, and current setting.
       </p>
     ),
+    bodyMarkdown:
+      "Open **Settings → Privacy** to see your install ID, last ping times, and current setting.",
   },
   {
     title: "Rectify",
@@ -23,6 +28,8 @@ const RIGHTS: Right[] = [
         not profile data.
       </p>
     ),
+    bodyMarkdown:
+      "There's nothing to rectify. The six fields are facts about your build, not profile data.",
   },
   {
     title: "Erase",
@@ -52,16 +59,32 @@ const RIGHTS: Right[] = [
         </p>
       </>
     ),
+    bodyMarkdown: [
+      `Rotate your install ID from **Settings → Privacy**. Old rows become unlinkable and age out at ${RETENTION.rawPingDays} days.`,
+      "",
+      "To delete them immediately, call the server-side erasure endpoint:",
+      "",
+      "```",
+      ERASE_ENDPOINT_SHAPE,
+      "```",
+      "",
+      "Or email [privacy@nteract.io](mailto:privacy@nteract.io) with your install ID.",
+    ].join("\n"),
   },
   {
     title: "Object / withdraw",
-    body: (
-      <p>Flip the setting off, any time. No penalty, no features lost.</p>
-    ),
+    body: <p>Flip the setting off, any time. No penalty, no features lost.</p>,
+    bodyMarkdown: "Flip the setting off, any time. No penalty, no features lost.",
   },
 ];
 
-function RightSection({ title, children }: { title: string; children: React.ReactNode }) {
+function RightSection({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
   return (
     <details className="group border-t py-4" style={{ borderColor: "var(--rule)" }}>
       <summary
@@ -100,3 +123,11 @@ export function Rights() {
     </section>
   );
 }
+
+Rights.toMarkdown = (_data: PlaceholderData): string => {
+  const lines = ["## Your rights", ""];
+  for (const r of RIGHTS) {
+    lines.push(`### ${r.title}`, "", r.bodyMarkdown, "");
+  }
+  return lines.join("\n").trimEnd();
+};

--- a/lib/blog-md.ts
+++ b/lib/blog-md.ts
@@ -1,31 +1,31 @@
 import type { PlaceholderData } from "fumadocs-core/mdx-plugins/remark-llms.runtime";
 
+import { blogCtaToMarkdown } from "@/components/blog/cta.md";
+import { BlogInlineCTA } from "@/components/blog/inline-cta";
+import { kbdToMarkdown } from "@/components/kbd.md";
+
 /**
- * Placeholder renderers for blog MDX components.
+ * Placeholder renderers for /blog/[slug]/llms.txt.
  *
- * Used by the /blog/[slug]/llms.txt route to resolve remarkLLMs
- * placeholders into plain markdown at build time.
+ * Convention for components referenced from blog MDX files:
+ *
+ *   Server component (default): attach `Component.toMarkdown` in the
+ *     same .tsx file. Resolver entry: `<Name>: <Name>.toMarkdown`.
+ *
+ *   "use client" component: define `<name>ToMarkdown` in a sibling
+ *     `<component>.md.ts` file. Static methods on a client component
+ *     are unreachable from server code (the import becomes a client
+ *     reference), so the markdown form must live in a non-client
+ *     module. Resolver entry: `<Name>: <name>ToMarkdown`.
+ *
+ * Both renderers MUST read from the same data; never duplicate content
+ * between the JSX view and the markdown view.
  */
 export const resolveBlogPlaceholders: Record<
   string,
   (data: PlaceholderData) => string
 > = {
-  Kbd({ children }) {
-    return `\`${children}\``;
-  },
-
-  BlogCTA() {
-    return [
-      "---",
-      "",
-      "[Download nteract](https://github.com/nteract/desktop/releases) · [Star on GitHub](https://github.com/nteract/desktop)",
-    ].join("\n");
-  },
-
-  BlogInlineCTA({ attributes, children }) {
-    const href = (attributes.href as string) ?? "";
-    const lead = (attributes.lead as string) ?? "";
-    const prefix = lead ? `${lead} ` : "";
-    return `${prefix}[${children}](${href})`;
-  },
+  Kbd: kbdToMarkdown,
+  BlogCTA: blogCtaToMarkdown,
+  BlogInlineCTA: BlogInlineCTA.toMarkdown,
 };

--- a/lib/telemetry-md.ts
+++ b/lib/telemetry-md.ts
@@ -1,13 +1,10 @@
 import { _markdown } from "@/content/telemetry.mdx";
 import { renderPlaceholder } from "fumadocs-core/mdx-plugins/remark-llms.runtime";
+
+import { OptOut } from "@/components/telemetry/opt-out";
+import { pingPreviewToMarkdown } from "@/components/telemetry/ping-preview.md";
+import { Receipt } from "@/components/telemetry/receipt";
 import { Rights } from "@/components/telemetry/rights";
-import {
-  EMISSION_GATES,
-  FIELDS,
-  NEVER_SENT,
-  OPT_OUT_PATHS,
-  RETENTION,
-} from "@/lib/telemetry-data";
 
 /**
  * Resolve the remarkLLMs markdown export from telemetry.mdx,
@@ -17,62 +14,9 @@ import {
  */
 export function resolveTelemetryMarkdown(): Promise<string> {
   return renderPlaceholder(_markdown, {
-    PingPreview() {
-      const lines = ["```", "{"];
-      for (const f of FIELDS) {
-        lines.push(`  "${f.name}": "${f.example}",`);
-      }
-      lines.push("}", "```");
-      return lines.join("\n");
-    },
-
+    PingPreview: pingPreviewToMarkdown,
     Rights: Rights.toMarkdown,
-
-    OptOut() {
-      const lines = [
-        "## How to opt out",
-        "",
-        ...OPT_OUT_PATHS.inApp.map((p) => `- **${p.label}.** ${p.description}`),
-        "",
-        `For locked-down deployments and CI images: ${OPT_OUT_PATHS.envVar}`,
-      ];
-      return lines.join("\n");
-    },
-
-    Receipt() {
-      const lines: string[] = [];
-
-      // Fields table
-      lines.push("## Exactly what's sent", "");
-      lines.push("| Field | Example | Description |", "|---|---|---|");
-      for (const f of FIELDS) {
-        lines.push(`| ${f.name} | \`${f.example}\` | ${f.description} |`);
-      }
-
-      // Never sent
-      lines.push("", "## What is never sent or stored", "");
-      for (const n of NEVER_SENT) lines.push(`- ${n}`);
-
-      // Emission gates
-      lines.push("", "## When a ping is suppressed", "");
-      lines.push("| Gate | Trigger |", "|---|---|");
-      for (const g of EMISSION_GATES) {
-        lines.push(`| ${g.name} | ${g.trigger} |`);
-      }
-
-      // Retention
-      lines.push("", "## Retention and schema evolution", "");
-      lines.push(
-        `- **Raw pings**: kept for ${RETENTION.rawPingDays} days, then deleted by a nightly cleanup job.`,
-      );
-      lines.push(
-        `- **Daily aggregate counts**: kept ${RETENTION.aggregatesKept}. No \`install_id\`; just counts grouped by ${RETENTION.rollupKeys.map((k) => "`" + k + "`").join(", ")}.`,
-      );
-      lines.push(
-        "- New fields may be added over time (additive only). Any field removal is a breaking change that gets a new route version (`/v2/ping`).",
-      );
-
-      return lines.join("\n");
-    },
+    OptOut: OptOut.toMarkdown,
+    Receipt: Receipt.toMarkdown,
   });
 }

--- a/lib/telemetry-md.ts
+++ b/lib/telemetry-md.ts
@@ -1,5 +1,4 @@
-import { _markdown } from "@/content/telemetry.mdx";
-import { renderPlaceholder } from "fumadocs-core/mdx-plugins/remark-llms.runtime";
+import type { PlaceholderData } from "fumadocs-core/mdx-plugins/remark-llms.runtime";
 
 import { OptOut } from "@/components/telemetry/opt-out";
 import { pingPreviewToMarkdown } from "@/components/telemetry/ping-preview.md";
@@ -7,16 +6,28 @@ import { Receipt } from "@/components/telemetry/receipt";
 import { Rights } from "@/components/telemetry/rights";
 
 /**
- * Resolve the remarkLLMs markdown export from telemetry.mdx,
- * replacing component placeholders with their static markdown form.
+ * Placeholder renderers for /telemetry/llms.txt.
  *
- * Used by the /telemetry/llms.txt route.
+ * Convention for components referenced from content/telemetry.mdx:
+ *
+ *   Server component (default): attach `Component.toMarkdown` in the
+ *     same .tsx file. Resolver entry: `<Name>: <Name>.toMarkdown`.
+ *
+ *   "use client" component: define `<name>ToMarkdown` in a sibling
+ *     `<component>.md.ts` file. Static methods on a client component
+ *     are unreachable from server code (the import becomes a client
+ *     reference), so the markdown form must live in a non-client
+ *     module. Resolver entry: `<Name>: <name>ToMarkdown`.
+ *
+ * Both renderers MUST read from the same data; never duplicate content
+ * between the JSX view and the markdown view.
  */
-export function resolveTelemetryMarkdown(): Promise<string> {
-  return renderPlaceholder(_markdown, {
-    PingPreview: pingPreviewToMarkdown,
-    Rights: Rights.toMarkdown,
-    OptOut: OptOut.toMarkdown,
-    Receipt: Receipt.toMarkdown,
-  });
-}
+export const resolveTelemetryPlaceholders: Record<
+  string,
+  (data: PlaceholderData) => string
+> = {
+  PingPreview: pingPreviewToMarkdown,
+  Rights: Rights.toMarkdown,
+  OptOut: OptOut.toMarkdown,
+  Receipt: Receipt.toMarkdown,
+};

--- a/lib/telemetry-md.ts
+++ b/lib/telemetry-md.ts
@@ -1,8 +1,8 @@
 import { _markdown } from "@/content/telemetry.mdx";
 import { renderPlaceholder } from "fumadocs-core/mdx-plugins/remark-llms.runtime";
+import { Rights } from "@/components/telemetry/rights";
 import {
   EMISSION_GATES,
-  ERASE_ENDPOINT_SHAPE,
   FIELDS,
   NEVER_SENT,
   OPT_OUT_PATHS,
@@ -26,36 +26,7 @@ export function resolveTelemetryMarkdown(): Promise<string> {
       return lines.join("\n");
     },
 
-    Rights() {
-      const lines = [
-        "## Your rights",
-        "",
-        "### Access",
-        "",
-        "Open **Settings → Privacy** to see your install ID, last ping times, and current setting.",
-        "",
-        "### Rectify",
-        "",
-        "There's nothing to rectify. The six fields are facts about your build, not profile data.",
-        "",
-        "### Erase",
-        "",
-        `Rotate your install ID from **Settings → Privacy**. Old rows become unlinkable and age out at ${RETENTION.rawPingDays} days.`,
-        "",
-        "To delete them immediately, call the server-side erasure endpoint:",
-        "",
-        "```",
-        ERASE_ENDPOINT_SHAPE,
-        "```",
-        "",
-        "Or email [privacy@nteract.io](mailto:privacy@nteract.io) with your install ID.",
-        "",
-        "### Object / withdraw",
-        "",
-        "Flip the setting off, any time. No penalty, no features lost.",
-      ];
-      return lines.join("\n");
-    },
+    Rights: Rights.toMarkdown,
 
     OptOut() {
       const lines = [


### PR DESCRIPTION
Every component referenced from an MDX file that's served at `/<page>/llms.txt` now exposes its markdown form alongside its React form. `lib/telemetry-md.ts` and `lib/blog-md.ts` are flat import-and-pluck shims. Whatever a component's JSX view says, its `toMarkdown` view now says the same thing from the same source of truth.

## The drift that prompted this

`Rights` had its content hardcoded in JSX in `rights.tsx` and again as markdown strings in `lib/telemetry-md.ts`. #631 had to edit both files to move one endpoint onto its own line. The other six components (`PingPreview`, `OptOut`, `Receipt`, `Kbd`, `BlogCTA`, `BlogInlineCTA`) were already pulling from shared data modules in spirit but the boilerplate in the resolver shims was still hand-rolled.

## The rule

Server component: `Component.toMarkdown` attaches as a static method in the same `.tsx` file. Resolver entry is `<Name>: <Name>.toMarkdown`.

`"use client"` component: `<name>ToMarkdown` is a named export in a sibling `<component>.md.ts` file. Resolver entry is `<Name>: <name>ToMarkdown`.

Both resolver shims carry a header comment documenting this.

## Why the split

Static methods on a `"use client"` component can't be called from the server-side resolver. When a server module imports a client module, the imports come back as client references, not the real values. `PingPreview.toMarkdown` silently evaluates to `undefined` and the placeholder renders empty. The build does not warn. Found this the hard way mid-refactor.

The three `"use client"` components (`PingPreview`, `BlogCTA`, `Kbd`) got sibling `.md.ts` files. The four server components (`Rights`, `OptOut`, `Receipt`, `BlogInlineCTA`) carry the function as a static method.

## Rights data

`Rights` content moved from inline JSX into a `const RIGHTS` array with paired `{ body, bodyMarkdown }` per entry. Both renderers iterate the array. Editing one field without its neighbor is now a 5-line-of-source violation rather than a cross-file one.

## Verification

`/telemetry/llms.txt`, `/blog/nteract-2.0/llms.txt`, and `/blog/security/llms.txt` produce byte-identical output against pre-refactor curl captures. All 46 vitest tests pass. Browser spot-check on `/telemetry` Erase accordion renders the three-block layout correctly.

## Follow-ups

- `lib/<page>-md.ts` route-level integration tests would formalize the fixture-diff check. Left out of this PR because vitest can't import `.mdx` without wiring a vite-side MDX plugin into the test config; that's a separate piece of work.