### PR TITLE
feat: custom 404 page and scanner probe short-circuit

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,40 @@
+import Link from "next/link";
+
+import { Logo } from "@/components/logo";
+import { NotFoundTracker } from "@/components/not-found-tracker";
+
+export default function NotFound() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center px-4 py-16">
+      <NotFoundTracker />
+      <div className="max-w-2xl mx-auto text-center">
+        <Logo className="w-24 h-24 mx-auto mb-8 opacity-50" />
+
+        <p className="text-sm uppercase tracking-widest text-gray-400 mb-2">
+          404
+        </p>
+        <h1 className="text-4xl font-bold text-gray-900 mb-3">
+          Page not found
+        </h1>
+        <p className="text-base text-gray-500 mb-8 max-w-md mx-auto">
+          We don&apos;t have a page at this URL.
+        </p>
+
+        <nav className="flex items-center justify-center gap-6 text-sm text-gray-500">
+          <Link href="/" className="hover:text-gray-900 transition-colors">
+            Home
+          </Link>
+          <Link href="/blog" className="hover:text-gray-900 transition-colors">
+            Blog
+          </Link>
+          <Link
+            href="/nightly"
+            className="hover:text-gray-900 transition-colors"
+          >
+            Nightly
+          </Link>
+        </nav>
+      </div>
+    </main>
+  );
+}

--- a/components/not-found-tracker.tsx
+++ b/components/not-found-tracker.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { track } from "@vercel/analytics";
+import { useEffect } from "react";
+
+export function NotFoundTracker() {
+  useEffect(() => {
+    track("not-found", {
+      path: window.location.pathname,
+      referrer: document.referrer || "direct",
+    });
+  }, []);
+  return null;
+}

--- a/middleware.test.ts
+++ b/middleware.test.ts
@@ -1,0 +1,111 @@
+import { NextRequest } from "next/server";
+import { describe, expect, it } from "vitest";
+
+import { middleware } from "@/middleware";
+
+function request(
+  path: string,
+  init: { method?: string; accept?: string } = {},
+): NextRequest {
+  const headers = new Headers();
+  if (init.accept) headers.set("accept", init.accept);
+  return new NextRequest(new URL(`http://localhost:3000${path}`), {
+    method: init.method ?? "GET",
+    headers,
+  });
+}
+
+describe("middleware scanner short-circuit", () => {
+  const scannerPaths = [
+    "/impressum",
+    "/Impressum",
+    "/IMPRESSUM",
+    "/Impressum.html",
+    "/impressum.htm",
+    "/impressum-datenschutz",
+    "/impressum-und-datenschutz",
+    "/imprint",
+    "/Imprint",
+    "/wp-admin",
+    "/wp-login.php",
+    "/wp-content/plugins/foo",
+    "/wordpress",
+    "/phpmyadmin",
+    "/PhpMyAdmin/",
+    "/pma/login.php",
+    "/xmlrpc.php",
+    "/cgi-bin/test",
+    "/.env",
+    "/.env.production",
+    "/.git/config",
+  ];
+
+  for (const path of scannerPaths) {
+    it(`returns a bare 404 with X-Robots-Tag: noindex for ${path}`, () => {
+      const response = middleware(request(path));
+      expect(response.status).toBe(404);
+      expect(response.headers.get("x-robots-tag")).toBe("noindex");
+    });
+  }
+});
+
+describe("middleware passthrough for real routes", () => {
+  const realPaths = ["/", "/blog", "/blog/nteract-2.0", "/telemetry", "/nightly"];
+
+  for (const path of realPaths) {
+    it(`does not return a synthetic 404 for ${path}`, () => {
+      const response = middleware(request(path));
+      expect(response.headers.get("x-robots-tag")).toBeNull();
+    });
+  }
+
+  it("does not short-circuit a typo path (lets Next.js render the 404 page)", () => {
+    const response = middleware(request("/typo-page"));
+    expect(response.headers.get("x-robots-tag")).toBeNull();
+  });
+});
+
+describe("middleware llms.txt rewrite (preserved)", () => {
+  it("rewrites / to /llms.txt when markdown is preferred", () => {
+    const response = middleware(
+      request("/", { accept: "text/markdown, text/html, */*" }),
+    );
+    const rewrite = response.headers.get("x-middleware-rewrite");
+    expect(rewrite).toContain("/llms.txt");
+  });
+
+  it("rewrites /blog/foo to /blog/foo/llms.txt when markdown is preferred", () => {
+    const response = middleware(
+      request("/blog/nteract-2.0", { accept: "text/markdown" }),
+    );
+    const rewrite = response.headers.get("x-middleware-rewrite");
+    expect(rewrite).toContain("/blog/nteract-2.0/llms.txt");
+  });
+
+  it("rewrites /telemetry to /telemetry/llms.txt when markdown is preferred", () => {
+    const response = middleware(
+      request("/telemetry", { accept: "text/markdown" }),
+    );
+    const rewrite = response.headers.get("x-middleware-rewrite");
+    expect(rewrite).toContain("/telemetry/llms.txt");
+  });
+
+  it("sets Vary: Accept on llms.txt-eligible routes", () => {
+    const response = middleware(request("/blog"));
+    expect(response.headers.get("vary")).toBe("Accept");
+  });
+
+  it("does not rewrite when the client prefers html", () => {
+    const response = middleware(
+      request("/blog", { accept: "text/html,application/xhtml+xml,*/*;q=0.9" }),
+    );
+    expect(response.headers.get("x-middleware-rewrite")).toBeNull();
+  });
+
+  it("does not rewrite on a HEAD request", () => {
+    const response = middleware(
+      request("/blog", { method: "HEAD", accept: "text/markdown" }),
+    );
+    expect(response.headers.get("x-middleware-rewrite")).toBeNull();
+  });
+});

--- a/middleware.ts
+++ b/middleware.ts
@@ -3,10 +3,27 @@ import { NextResponse, type NextRequest } from "next/server";
 import { prefersMarkdown } from "@/lib/accept";
 
 export const config = {
-  matcher: ["/", "/blog", "/blog/:slug", "/telemetry"],
+  matcher: ["/((?!_next/|api/).*)"],
 };
 
-function rewriteTarget(pathname: string): string | null {
+const SCANNER_PATTERNS: readonly RegExp[] = [
+  /^\/impressum/i,
+  /^\/imprint/i,
+  /^\/wp-/i,
+  /^\/wordpress/i,
+  /^\/phpmyadmin/i,
+  /^\/pma\//i,
+  /^\/xmlrpc\.php/i,
+  /^\/cgi-bin/i,
+  /^\/\.env/i,
+  /^\/\.git/i,
+];
+
+function isScannerProbe(pathname: string): boolean {
+  return SCANNER_PATTERNS.some((re) => re.test(pathname));
+}
+
+function llmsRewriteTarget(pathname: string): string | null {
   if (pathname === "/" || pathname === "/blog") {
     return "/llms.txt";
   }
@@ -19,11 +36,33 @@ function rewriteTarget(pathname: string): string | null {
   return null;
 }
 
+function isLlmsCandidate(pathname: string): boolean {
+  return (
+    pathname === "/" ||
+    pathname === "/blog" ||
+    pathname === "/telemetry" ||
+    pathname.startsWith("/blog/")
+  );
+}
+
 export function middleware(request: NextRequest) {
+  const pathname = request.nextUrl.pathname;
+
+  if (isScannerProbe(pathname)) {
+    return new NextResponse(null, {
+      status: 404,
+      headers: { "X-Robots-Tag": "noindex" },
+    });
+  }
+
+  if (!isLlmsCandidate(pathname)) {
+    return NextResponse.next();
+  }
+
   const wantsMarkdown =
     request.method === "GET" && prefersMarkdown(request.headers.get("accept"));
 
-  const target = wantsMarkdown ? rewriteTarget(request.nextUrl.pathname) : null;
+  const target = wantsMarkdown ? llmsRewriteTarget(pathname) : null;
 
   let response: NextResponse;
   if (target) {


### PR DESCRIPTION
The Vercel Analytics "Pages" panel was pulling in a long tail of `/impressum*` and other scanner-bait paths: bots probing for German legal pages, WordPress endpoints, leaked secrets. None of those routes exist. The dashboard is hosted by Vercel, so the fix lives here. Stop firing pageviews for scanner probes, and add a separate signal for real link rot.

## Scanner short-circuit

`middleware.ts` matcher broadens to all non-internal paths. Known bot probe patterns return a bare 404 with `X-Robots-Tag: noindex`:

- `/impressum*`, `/imprint*` (German Impressum probes)
- `/wp-*`, `/wordpress*`
- `/phpmyadmin*`, `/pma/*`
- `/xmlrpc.php`, `/cgi-bin*`
- `/.env*`, `/.git*`

All case-insensitive, anchored at path start. The response skips the React tree, so `<Analytics />` never loads. No pageview, no dashboard entry.

llms.txt Accept negotiation is unchanged. The matcher widened, but the rewrite + `Vary: Accept` logic is gated inside the function so behavior on `/`, `/blog`, `/blog/:slug`, `/telemetry` is preserved.

## Custom not-found page

`app/not-found.tsx` replaces Next.js's default. Styling matches `app/page.tsx`. HTTP 404 status comes from Next.js automatically.

## Link-rot signal

`components/not-found-tracker.tsx` mounts inside the not-found page and fires `track('not-found', { path, referrer })` via `@vercel/analytics`. The default pageview still records, so the Pages panel still surfaces 404 paths, but Events gains a stream tagged with referrer. Any `not-found` event whose referrer is not `direct` is a real broken inbound link worth chasing. Once a pattern surfaces, drop a redirect into `next.config.ts:redirects()` next to the existing `/desktop` -> `/`.

## Design decisions

Middleware short-circuit over `<Analytics beforeSend>`. `beforeSend` runs in the browser after the analytics script loads. It would clean up the dashboard but still ship the React tree and analytics JS to every scanner. Middleware kills the request at the edge. Bots get a 404 status and nothing else. Cost is one extra regex check per request, which is negligible.

Custom `not-found` event instead of overloading the pageview. Vercel pageviews can't carry custom props, so referrer would be lost. A separate event gives the Events view a proper actionable list without losing the Pages-view 404 entries.

## Behavior

| Path | Status | Body | Analytics |
|---|---|---|---|
| `/impressum`, `/wp-admin`, `/.env` | 404 + `X-Robots-Tag: noindex` | empty | none |
| `/typo-page` | 404 | custom 404 page | pageview + `not-found` event |
| `/blog` | 200 | blog index | pageview |
| `/blog` with `Accept: text/markdown` | 200 | llms.txt | pageview |

## Tests

`middleware.test.ts` covers scanner short-circuit (21 probe variants from the dashboard, all return `404` + `X-Robots-Tag: noindex`), passthrough on real routes and unknown typos, and the llms.txt rewrite cases (markdown-preferred, html-preferred, HEAD, `Vary: Accept`). 79/79 in the full suite pass.

Post-deploy spot check: open the not-found page on the preview URL, then confirm the Vercel Analytics Events panel shows a `not-found` entry with `path` and `referrer` props.
