### PR TITLE
chore: point links at nteract/nteract after repo rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nteract.io
 
-Landing page for [nteract desktop](https://github.com/nteract/desktop) — native interactive notebooks.
+Landing page for [nteract desktop](https://github.com/nteract/nteract) — native interactive notebooks.
 
 ## Development
 

--- a/app/(nightly)/nightly/page.tsx
+++ b/app/(nightly)/nightly/page.tsx
@@ -3,7 +3,7 @@ import { NightlyDownloads } from "./downloads";
 import { Fireflies } from "./fireflies";
 
 const MANIFEST_URL =
-  "https://github.com/nteract/desktop/releases/download/nightly-latest/latest.json";
+  "https://github.com/nteract/nteract/releases/download/nightly-latest/latest.json";
 
 interface NightlyManifest {
   version: string;
@@ -73,7 +73,7 @@ function Sparkle({ size, opacity }: { size: number; opacity: number }) {
 // Construct direct download URLs from the version
 // The manifest URLs point to .tar.gz (for auto-update), but we want .dmg for direct download
 function getDownloadUrl(version: string, platform: "macos" | "windows" | "linux"): string {
-  const base = `https://github.com/nteract/desktop/releases/download/v${version}`;
+  const base = `https://github.com/nteract/nteract/releases/download/v${version}`;
   switch (platform) {
     case "macos":
       return `${base}/nteract-nightly-darwin-arm64.dmg`;
@@ -216,7 +216,7 @@ export default async function NightlyPage() {
           <p className="text-white/70">
             Unable to fetch nightly releases. Check{" "}
             <a
-              href="https://github.com/nteract/desktop/releases"
+              href="https://github.com/nteract/nteract/releases"
               className="underline hover:text-white"
             >
               GitHub Releases
@@ -231,13 +231,13 @@ export default async function NightlyPage() {
             Stable Release
           </a>
           <a
-            href="https://github.com/nteract/desktop"
+            href="https://github.com/nteract/nteract"
             className="hover:text-white transition-colors"
           >
             GitHub
           </a>
           <a
-            href="https://github.com/nteract/desktop/releases"
+            href="https://github.com/nteract/nteract/releases"
             className="hover:text-white transition-colors"
           >
             All Releases

--- a/components/blog/cta.md.ts
+++ b/components/blog/cta.md.ts
@@ -10,5 +10,5 @@ export const blogCtaToMarkdown = (_data: PlaceholderData): string =>
   [
     "---",
     "",
-    "[Download nteract](https://github.com/nteract/desktop/releases) · [Star on GitHub](https://github.com/nteract/desktop)",
+    "[Download nteract](https://github.com/nteract/nteract/releases) · [Star on GitHub](https://github.com/nteract/nteract)",
   ].join("\n");

--- a/components/blog/cta.tsx
+++ b/components/blog/cta.tsx
@@ -19,7 +19,7 @@ const platformFiles: Record<Platform, string | null> = {
 };
 
 function getDownloadUrl(version: string, file: string): string {
-  return `https://github.com/nteract/desktop/releases/download/v${version}/${file}`;
+  return `https://github.com/nteract/nteract/releases/download/v${version}/${file}`;
 }
 
 export function BlogCTA() {
@@ -37,7 +37,7 @@ export function BlogCTA() {
   const href =
     file && version
       ? getDownloadUrl(version, file)
-      : "https://github.com/nteract/desktop/releases";
+      : "https://github.com/nteract/nteract/releases";
 
   const label =
     platform === "Windows"
@@ -55,7 +55,7 @@ export function BlogCTA() {
         {label}
       </a>
       <a
-        href="https://github.com/nteract/desktop"
+        href="https://github.com/nteract/nteract"
         target="_blank"
         rel="noopener noreferrer"
         className="inline-flex items-center gap-2 border border-[#484848] px-8 py-4 font-headline font-bold transition-colors hover:bg-[#131313] no-underline"

--- a/components/home/download-buttons.tsx
+++ b/components/home/download-buttons.tsx
@@ -16,7 +16,7 @@ type PlatformMeta = {
 };
 
 const LINUX_INSTALL_CMD = "curl -fsSL https://sh.nteract.io | bash";
-const FALLBACK_RELEASES_URL = "https://github.com/nteract/desktop/releases";
+const FALLBACK_RELEASES_URL = "https://github.com/nteract/nteract/releases";
 
 const AppleIcon = () => (
   <svg className="h-5 w-5" viewBox="0 0 24 24" fill="currentColor">
@@ -107,7 +107,7 @@ type UADataLike = {
 };
 
 function getDownloadUrl(version: string, file: string): string {
-  return `https://github.com/nteract/desktop/releases/download/v${version}/${file}`;
+  return `https://github.com/nteract/nteract/releases/download/v${version}/${file}`;
 }
 
 export function DownloadButtons({ version }: { version: string | null }) {

--- a/content/blog/nteract-2.0.mdx
+++ b/content/blog/nteract-2.0.mdx
@@ -39,7 +39,7 @@ The two main modes are:
 
 On top of that, nteract wants you to be able to iterate fast. There are prewarmed environments ready to go with the dependencies you configure.
 
-Whether you're on `uv`, `conda`, or `pixi`[*](https://github.com/nteract/desktop/issues/671), we've got you covered.
+Whether you're on `uv`, `conda`, or `pixi`[*](https://github.com/nteract/nteract/issues/671), we've got you covered.
 
 <EnvPicker uvText="Pure PyPI. Blazing fast installs." condaText="Public and private channels." pixiText="The new kid. We're into it." />
 
@@ -109,12 +109,12 @@ Your agent gets full access to:
 
 ## What's next
 
-* [Runtime Decoupling](https://github.com/nteract/desktop/milestone/4): decompose kernel ownership into per-runtime Automerge peers.
+* [Runtime Decoupling](https://github.com/nteract/nteract/milestone/4): decompose kernel ownership into per-runtime Automerge peers.
   - This unlocks both remote runtimes and alternative document types (who wants markdown instead of ipynb 🙋‍♂️ 🙋‍♀️)
-* [Sandboxing](https://github.com/nteract/desktop/issues/1307): OS-level isolation per runtime so agents can compute freely without escaping their notebook's boundaries
-* [Multiplayer widgets](https://github.com/nteract/desktop/milestone/5): move interactive widgets into a CRDT document for collaboration (and reliability for that matter)
-* [More Rich Media](https://github.com/nteract/desktop/milestone/6): support GeoJSON, Vega/Vegalite, Plotly out of the box
+* [Sandboxing](https://github.com/nteract/nteract/issues/1307): OS-level isolation per runtime so agents can compute freely without escaping their notebook's boundaries
+* [Multiplayer widgets](https://github.com/nteract/nteract/milestone/5): move interactive widgets into a CRDT document for collaboration (and reliability for that matter)
+* [More Rich Media](https://github.com/nteract/nteract/milestone/6): support GeoJSON, Vega/Vegalite, Plotly out of the box
 
-We'd love to hear what you want to build with it. [Drop us an issue on GitHub](https://github.com/nteract/desktop/issues).
+We'd love to hear what you want to build with it. [Drop us an issue on GitHub](https://github.com/nteract/nteract/issues).
 
 <BlogCTA />

--- a/content/blog/security.mdx
+++ b/content/blog/security.mdx
@@ -92,7 +92,7 @@ The iframe also enforces a Content Security Policy. Scripts and stylesheets can 
 
 For organizations with stricter requirements I could see us locking down `connect-src`, restricting script sources to specific domains. These are levers we'd like to expose.
 
-<BlogInlineCTA href="https://github.com/nteract/desktop/issues" lead="Have stricter requirements?">
+<BlogInlineCTA href="https://github.com/nteract/nteract/issues" lead="Have stricter requirements?">
   Tell us what your team needs
 </BlogInlineCTA>
 
@@ -126,7 +126,7 @@ Every cloud-hosted notebook service is a target for attackers, subpoenas, and da
 
 The original nteract was Electron backed. Electron bundles Chromium with full Node.js access. Every renderer is one `nodeIntegration: true` away from `require('child_process')`. It was a lot of surface to defend.
 
-[Tauri](https://tauri.app/) flips it. The frontend is a native webview with no Node.js. Native capabilities like the filesystem, shell, and HTTP are granted from Rust through an explicit [capabilities config](https://github.com/nteract/desktop/issues/908). If it isn't granted, the frontend can't do it. Even if an output iframe somehow escaped its sandbox, there's nothing to hijack on the other side. The webview is a dead end by design.
+[Tauri](https://tauri.app/) flips it. The frontend is a native webview with no Node.js. Native capabilities like the filesystem, shell, and HTTP are granted from Rust through an explicit [capabilities config](https://github.com/nteract/nteract/issues/908). If it isn't granted, the frontend can't do it. Even if an output iframe somehow escaped its sandbox, there's nothing to hijack on the other side. The webview is a dead end by design.
 
 ## The philosophy
 
@@ -143,9 +143,9 @@ None of these are revolutionary ideas individually. But notebooks have operated 
 
 ## What's next
 
-* [Secret redaction](https://github.com/nteract/desktop/issues/1557): if your code accidentally prints an API key, nteract catches it at the runtime level and redacts it before any client whether the UI, agent, or blob store ever sees the value.
-* [Runtime sandboxing](https://github.com/nteract/desktop/issues/1307): OS-level process isolation for kernel subprocesses, so untrusted code runs with only the access it needs. Given how people expect notebooks to work, we'd expect opt-in at first, with the long-term goal of sandboxing agent-initiated sessions by default.
-* [Remote runtimes over SSH](https://github.com/nteract/desktop/issues/1334): run kernels on remote machines, tunneled through SSH. No new auth systems, no exposed ports.
+* [Secret redaction](https://github.com/nteract/nteract/issues/1557): if your code accidentally prints an API key, nteract catches it at the runtime level and redacts it before any client whether the UI, agent, or blob store ever sees the value.
+* [Runtime sandboxing](https://github.com/nteract/nteract/issues/1307): OS-level process isolation for kernel subprocesses, so untrusted code runs with only the access it needs. Given how people expect notebooks to work, we'd expect opt-in at first, with the long-term goal of sandboxing agent-initiated sessions by default.
+* [Remote runtimes over SSH](https://github.com/nteract/nteract/issues/1334): run kernels on remote machines, tunneled through SSH. No new auth systems, no exposed ports.
 
 
 <BlogCTA />

--- a/content/telemetry.mdx
+++ b/content/telemetry.mdx
@@ -22,4 +22,4 @@ nteract is a [NumFOCUS](https://numfocus.org/) sponsored project. NumFOCUS's own
 
 Privacy questions: [privacy@nteract.io](mailto:privacy@nteract.io).
 
-Source: [github.com/nteract/desktop](https://github.com/nteract/desktop).
+Source: [github.com/nteract/nteract](https://github.com/nteract/nteract).

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -6,10 +6,10 @@ export const siteConfig = {
   blogDescription:
     "Product notes, technical writing, and release stories from the nteract team.",
   stableManifestUrl:
-    "https://github.com/nteract/desktop/releases/download/stable-latest/latest.json",
+    "https://github.com/nteract/nteract/releases/download/stable-latest/latest.json",
   links: {
-    github: "https://github.com/nteract/desktop",
-    releases: "https://github.com/nteract/desktop/releases",
+    github: "https://github.com/nteract/nteract",
+    releases: "https://github.com/nteract/nteract/releases",
     rss: "/feed.xml",
   },
   quote: {


### PR DESCRIPTION
The `nteract/desktop` repo was renamed to `nteract/nteract`. This updates every hard-coded link on the site, blog, and downloader to the new slug.

GitHub keeps the old URLs working via redirect, so nothing is broken on `main` today. The motivation is cosmetic: canonical URLs, no surprise redirects in `view-source`, and the nightly `latest.json` fetch lands on the right host without a 301.

## What changed

| Area | Files |
| --- | --- |
| Site config | `lib/site.ts` (github, releases, nightly manifest) |
| Pages | `app/(nightly)/nightly/page.tsx`, `content/telemetry.mdx` |
| Blog | `content/blog/nteract-2.0.mdx`, `content/blog/security.mdx` |
| Components | `components/home/download-buttons.tsx`, `components/blog/cta.tsx`, `components/blog/cta.md.ts` |
| Misc | `README.md` |

Not touched: `.context/superpowers/*` plan docs (historical, frozen in time) and the `.claude/worktrees/telemetry-page/` worktree (separate branch, will follow on its own merge).

## Test plan

- [ ] Preview deploy renders the nightly page and download buttons
- [ ] Click through to GitHub from the homepage CTA, blog CTA, and telemetry page
- [ ] Nightly `latest.json` fetch resolves against `nteract/nteract`
