### PR TITLE
feat: promote the changelog from the homepage with its own OG card

### DIFF
--- a/app/(changelog)/changelog/page.tsx
+++ b/app/(changelog)/changelog/page.tsx
@@ -11,7 +11,9 @@ import { absoluteUrl, siteConfig } from "@/lib/site";
 export const dynamic = "force-dynamic";
 
 const description =
-  "Every nteract stable release, in human terms. What changed, why it matters, and what to try next.";
+  "Local-first notebooks, built from the ground up for mingling with agents. Realtime collab with a colorful, jazzy streak. Here's how it gets better, release by release.";
+
+const ogImage = "https://img.runt.run/2026/06/08/a633578f00f5.png";
 
 export const metadata: Metadata = {
   title: "Changelog",
@@ -27,12 +29,13 @@ export const metadata: Metadata = {
     description,
     url: absoluteUrl("/changelog"),
     type: "website",
-    images: [absoluteUrl("/opengraph-image")],
+    images: [ogImage],
   },
   twitter: {
     card: "summary_large_image",
     title: `Changelog | ${siteConfig.name}`,
     description,
+    images: [ogImage],
   },
 };
 
@@ -80,9 +83,9 @@ export default async function ChangelogPage() {
         <h1 className="text-[var(--ink)]">Changelog</h1>
 
         <p className="mb-16 max-w-2xl text-xl leading-snug text-[var(--muted)]">
-          A local AI-native notebook workspace where humans and agents
-          collaborate through the same live document and runtime. Here is how it
-          gets better, release by release.
+          Local-first notebooks, built from the ground up for mingling with
+          agents. Realtime collab with a colorful, jazzy streak. Here&apos;s how
+          it gets better, release by release.
         </p>
 
         {rendered.length > 0 ? (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -39,13 +39,13 @@ export default async function Home() {
 
         <div className="mt-16 flex flex-col items-center justify-center gap-4 sm:flex-row">
           <Link
-            href="/blog/nteract-2.0"
+            href="/changelog"
             className="group inline-flex items-center gap-3 text-sm text-gray-500 transition-colors hover:text-gray-900"
           >
-            <span className="text-base">🎉</span>
+            <span className="text-base">📰</span>
             <span>
-              <span className="font-medium text-gray-700 group-hover:text-gray-900">nteract 2.0 is here</span>
-              {" "}— read the launch post
+              <span className="font-medium text-gray-700 group-hover:text-gray-900">nteract 2.5 is out</span>
+              {". "}Read the changelog
             </span>
             <span className="transition-transform group-hover:translate-x-0.5">→</span>
           </Link>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -23,6 +23,21 @@ export default async function Home() {
   return (
     <main className="flex min-h-screen flex-col items-center justify-center px-4 py-16">
       <div className="max-w-2xl mx-auto text-center">
+        <Link
+          href="/changelog"
+          className="group mb-10 inline-flex items-center gap-2 rounded-full border border-gray-200 bg-white py-1 pl-1.5 pr-4 text-sm shadow-sm transition hover:border-gray-300 hover:shadow"
+        >
+          <span className="rounded-full bg-accent px-2.5 py-0.5 text-xs font-semibold text-white">
+            New
+          </span>
+          <span className="font-medium text-gray-700 transition-colors group-hover:text-gray-900">
+            nteract 2.5 is out
+          </span>
+          <span className="text-gray-400 transition-transform group-hover:translate-x-0.5">
+            →
+          </span>
+        </Link>
+
         <Logo className="w-40 h-40 mx-auto mb-8" />
 
         <p className="text-sm uppercase tracking-widest text-gray-400 mb-2">
@@ -37,26 +52,17 @@ export default async function Home() {
 
         <DownloadButtons version={version} />
 
-        <div className="mt-16 flex flex-col items-center justify-center gap-4 sm:flex-row">
-          <Link
-            href="/changelog"
-            className="group inline-flex items-center gap-3 text-sm text-gray-500 transition-colors hover:text-gray-900"
-          >
-            <span className="text-base">📰</span>
-            <span>
-              <span className="font-medium text-gray-700 group-hover:text-gray-900">nteract 2.5 is out</span>
-              {". "}Read the changelog
-            </span>
-            <span className="transition-transform group-hover:translate-x-0.5">→</span>
-          </Link>
+        <div className="mt-12">
           <Link
             href="/agents"
-            className="group inline-flex items-center gap-3 text-sm text-gray-500 transition-colors hover:text-gray-900"
+            className="group inline-flex items-center gap-2 text-sm text-gray-500 transition-colors hover:text-gray-900"
           >
             <span className="text-base">🤖</span>
             <span>
-              <span className="font-medium text-gray-700 group-hover:text-gray-900">Using agents?</span>
-              {" "}install the plugins
+              <span className="font-medium text-gray-700 group-hover:text-gray-900">
+                Using agents?
+              </span>{" "}
+              Install the plugins
             </span>
             <span className="transition-transform group-hover:translate-x-0.5">→</span>
           </Link>


### PR DESCRIPTION
The homepage still sent people to the year-old 2.0 launch post. Now it points at the changelog: "nteract 2.5 is out. Read the changelog."

The `/changelog` page also gets its own social card, a composite of the brand panel and a live MathNet crossfilter rendered in nteract, instead of borrowing the generic site OG. And the page copy drops the "AI-native workspace" boilerplate for something with a voice: local-first, built for mingling with agents, jazzy realtime collab.

Changed:

- `app/page.tsx` — homepage callout now links to `/changelog`
- `app/(changelog)/changelog/page.tsx` — OG + Twitter image, reworked description and on-page subtitle
