### PR TITLE
docs(changelog): publish 2.6 ergonomics notes + add-ons, 2.7 commenting drafts

### DIFF
--- a/app/(changelog)/changelog/[version]/page.tsx
+++ b/app/(changelog)/changelog/[version]/page.tsx
@@ -129,6 +129,7 @@ export default async function ChangelogVersionPage({
             <div className="overflow-hidden border border-[var(--rule)]">
               <video
                 src={entry.heroVideo}
+                poster={entry.heroVideoPoster}
                 autoPlay
                 muted
                 loop

--- a/app/(changelog)/changelog/page.tsx
+++ b/app/(changelog)/changelog/page.tsx
@@ -13,6 +13,8 @@ export const dynamic = "force-dynamic";
 const description =
   "Local-first notebooks, built from the ground up for mingling with agents. Realtime collab with a colorful, jazzy streak. Here's how it gets better, release by release.";
 
+// Handcrafted generic changelog card. Intentionally not a per-release image:
+// the index represents the whole changelog, so it keeps its own card.
 const ogImage = "https://img.runt.run/2026/06/08/a633578f00f5.png";
 
 export const metadata: Metadata = {

--- a/app/globals.css
+++ b/app/globals.css
@@ -151,6 +151,16 @@ body {
         @apply rounded bg-accent/15;
     }
 
+    /* Dual-theme tokens: light palette on the light changelog blocks,
+       dark palette under prose-invert (the blog's black code blocks). */
+    .nteract-prose [data-rehype-pretty-code-figure] code span {
+        color: var(--shiki-light);
+    }
+
+    .nteract-prose.prose-invert [data-rehype-pretty-code-figure] code span {
+        color: var(--shiki-dark);
+    }
+
     /* ──────────────────────────────────────
      Dark mode / prose-invert — Monolith
      ────────────────────────────────────── */

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { Logo } from "@/components/logo";
 import { DownloadButtons } from "@/components/home/download-buttons";
 import { SiteFooter, SiteHeader } from "@/components/site-shell";
+import { getAllEntries } from "@/lib/changelog";
 import { siteConfig } from "@/lib/site";
 
 async function getStableVersion(): Promise<string | null> {
@@ -20,6 +21,7 @@ async function getStableVersion(): Promise<string | null> {
 
 export default async function Home() {
   const version = await getStableVersion();
+  const [latestEntry] = await getAllEntries({ includeUnpublished: false });
 
   return (
     <div className="flex min-h-screen flex-col">
@@ -27,14 +29,14 @@ export default async function Home() {
       <main className="flex flex-1 flex-col items-center justify-center px-4 py-16">
         <div className="max-w-2xl mx-auto text-center">
           <Link
-            href="/changelog"
+            href={latestEntry ? `/changelog/${latestEntry.version}` : "/changelog"}
             className="group mb-10 inline-flex items-center gap-2 rounded-full border border-gray-200 bg-white py-1 pl-1.5 pr-4 text-sm shadow-sm transition hover:border-gray-300 hover:shadow"
           >
             <span className="rounded-full bg-accent px-2.5 py-0.5 text-xs font-semibold text-white">
               New
             </span>
             <span className="font-medium text-gray-700 transition-colors group-hover:text-gray-900">
-              nteract 2.5 is out
+              {latestEntry ? `nteract ${latestEntry.version} is out` : "See what's new"}
             </span>
             <span className="text-gray-400 transition-transform group-hover:translate-x-0.5">
               →

--- a/components/changelog/changelog-feed-entry.tsx
+++ b/components/changelog/changelog-feed-entry.tsx
@@ -74,6 +74,7 @@ export function ChangelogFeedEntry({ entry, children }: ChangelogFeedEntryProps)
             <div className="mb-6 overflow-hidden border border-[var(--rule)]">
               <video
                 src={entry.heroVideo}
+                poster={entry.heroVideoPoster}
                 autoPlay
                 muted
                 loop

--- a/components/mdx-components.tsx
+++ b/components/mdx-components.tsx
@@ -14,6 +14,7 @@ import { IframeIsolationDiagram } from "@/components/blog/iframe-isolation-diagr
 import { SocketDiagram } from "@/components/blog/socket-diagram";
 import { TauriComparison } from "@/components/blog/tauri-comparison";
 import { Video } from "@/components/video";
+import { RuntimeBadge } from "@/components/runtime-badge";
 import { OptOut } from "@/components/telemetry/opt-out";
 import { PingPreview } from "@/components/telemetry/ping-preview";
 import { Receipt } from "@/components/telemetry/receipt";
@@ -123,6 +124,7 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
     SocketDiagram,
     TauriComparison,
     Video,
+    RuntimeBadge,
     OptOut,
     PingPreview,
     Receipt,

--- a/components/mdx-components.tsx
+++ b/components/mdx-components.tsx
@@ -13,6 +13,7 @@ import { Peekaboo } from "@/components/blog/peekaboo";
 import { IframeIsolationDiagram } from "@/components/blog/iframe-isolation-diagram";
 import { SocketDiagram } from "@/components/blog/socket-diagram";
 import { TauriComparison } from "@/components/blog/tauri-comparison";
+import { Video } from "@/components/video";
 import { OptOut } from "@/components/telemetry/opt-out";
 import { PingPreview } from "@/components/telemetry/ping-preview";
 import { Receipt } from "@/components/telemetry/receipt";
@@ -121,6 +122,7 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
     IframeIsolationDiagram,
     SocketDiagram,
     TauriComparison,
+    Video,
     OptOut,
     PingPreview,
     Receipt,

--- a/components/runtime-badge.tsx
+++ b/components/runtime-badge.tsx
@@ -1,0 +1,190 @@
+import { ServerCog } from "lucide-react";
+import type { SVGProps } from "react";
+
+import { cn } from "@/lib/utils";
+
+type IconProps = SVGProps<SVGSVGElement>;
+
+/** Python logo mark. Ported from nteract's environment icon set. */
+function PythonIcon({ className, ...props }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
+      <path d="M12 9h-7a2 2 0 0 0 -2 2v4a2 2 0 0 0 2 2h3" />
+      <path d="M12 15h7a2 2 0 0 0 2 -2v-4a2 2 0 0 0 -2 -2h-3" />
+      <path d="M8 9v-4a2 2 0 0 1 2 -2h4a2 2 0 0 1 2 2v5a2 2 0 0 1 -2 2h-4a2 2 0 0 0 -2 2v5a2 2 0 0 0 2 2h4a2 2 0 0 0 2 -2v-4" />
+      <path d="M11 6l0 .01" />
+      <path d="M13 18l0 .01" />
+    </svg>
+  );
+}
+
+/** Deno logo mark. */
+function DenoIcon({ className, ...props }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
+      <path d="M3 12a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" />
+      <path d="M13.47 20.882l-1.47 -5.882c-2.649 -.088 -5 -1.624 -5 -3.5c0 -1.933 2.239 -3.5 5 -3.5s4 1 5 3c.024 .048 .69 2.215 2 6.5" />
+      <path d="M12 11h.01" />
+    </svg>
+  );
+}
+
+/** uv logo mark. */
+function UvIcon({ className, ...props }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 41 41"
+      fill="currentColor"
+      className={className}
+      {...props}
+    >
+      <path d="M-5.28619e-06 0.168629L0.0843098 20.1685L0.151762 36.1683C0.161075 38.3774 1.95947 40.1607 4.16859 40.1514L20.1684 40.084L30.1684 40.0418L31.1852 40.0375C33.3877 40.0282 35.1683 38.2026 35.1683 36V36L37.0003 36L37.0003 39.9992L40.1683 39.9996L39.9996 -9.94653e-07L21.5998 0.0775689L21.6774 16.0185L21.6774 25.9998L20.0774 25.9998L18.3998 25.9998L18.4774 16.032L18.3998 0.0910593L-5.28619e-06 0.168629Z" />
+    </svg>
+  );
+}
+
+/** Conda logo mark. */
+function CondaIcon({ className, ...props }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 23.565 27.149"
+      fill="currentColor"
+      stroke="currentColor"
+      strokeWidth="0.25px"
+      className={className}
+      {...props}
+    >
+      <path
+        d="M47.3 23.46c-.69-1.27-2.08-3.82-4.51-6.25-.81 3.47-.81 6.48-.69 7.99-.12 0 2.2-1.16 5.2-1.74zM36.54 28.32c-1.27-1.04-3.7-2.89-7.28-4.4.92 3.82 2.43 6.6 3.24 7.99 0 .23 1.62-1.74 4.05-3.59zM50.67 20.08c.81-2.08 2.31-5.09 4.74-8.22-1.5-2.66-3.58-5.32-6.36-7.64-2.2 2.78-3.7 5.56-4.74 8.33 3.12 2.66 5.09 5.44 6.36 7.52zM29.15 36.66c-1.22-.22-2.56-.41-4-.52a40.19 40.19 0 0 0-5.77-.06c1.01 1.29 2.24 2.71 3.73 4.14A39.43 39.43 0 0 0 26.35 43c.35-1.03.77-2.12 1.28-3.28a43.76 43.76 0 0 1 1.51-3.06zM11.92 49.15c4.16-2.66 8.09-3.82 10.75-4.17-2.08-1.74-5.09-4.51-7.52-8.33-3.47.69-7.01 2.02-10.36 4.33 1.97 3.47 4.47 6.2 7.12 8.17zM25.21 48.11c-1.62.12-5.56.34-10.19 3.12 4.28 2.66 8.22 4.06 10.19 4.52-.35-2.55-.35-5.21 0-7.64zM39.21 14.02c-2.54-1.74-5.78-3.24-9.83-4.17-.81 3.47-.92 6.71-.69 9.49 3.93 1.27 6.94 3.12 9.02 4.63 0-2.31.35-5.9 1.5-9.95z"
+        fillRule="evenodd"
+        transform="matrix(.26458 0 0 .26458 -.189 -.253)"
+      />
+      <path
+        d="M14.22 17.73c1.52-.19 3.32-.3 5.35-.22 1.82.08 3.44.3 4.83.56.29-3.12.58-6.24.88-9.37a45.326 45.326 0 0 0-5.82 4.02 45.63 45.63 0 0 0-5.23 5z"
+        fillRule="evenodd"
+        strokeLinecap="round"
+        transform="matrix(.26458 0 0 .26458 -.189 -.253)"
+      />
+      <path
+        d="M31.2 5.66c2.19.64 4.61 1.55 7.12 2.84.75.38 1.46.78 2.13 1.17a33.466 33.466 0 0 1 4.63-8.01c-2.15.36-4.53.88-7.08 1.62-2.53.73-4.8 1.55-6.8 2.38Z"
+        transform="matrix(.26458 0 0 .26458 -.189 -.253)"
+      />
+      <path
+        d="M9.14 51.23c-2.66-2.2-5.32-5.09-7.4-8.68C.58 48.45.58 54.7 1.51 60.49c2.2-4.05 4.86-6.94 7.63-9.26ZM86.84 81.09c-7.28-6.94-8.79-11.46-14.91-6.71C55.17 87.57 31 79.7 25.91 59.22c-.92-.12-7.4-1.39-13.99-5.9-3.24 2.55-6.59 6.48-9.37 12.15h-.12c10.52 39.81 61.74 49.07 85.44 24.19 3.93-4.17.35-7.06-1.04-8.56zM69.26 6.58c-3.35 1.62-6.01 3.7-8.09 5.9 1.73 3.7 2.54 7.06 3.01 9.14 3.24-2.55 6.47-4.05 8.44-4.86-.23-2.31-1.04-6.6-3.35-10.18zM57.59 16.75a26.405 26.405 0 0 0-3.02 6.27c.8.04 1.66.12 2.56.23.82.1 1.6.23 2.32.38-.13-.88-.3-1.84-.55-2.86-.38-1.52-.84-2.87-1.32-4.02zM58.67 8.08c1.04-.98 2.3-2.05 3.78-3.1 1.32-.94 2.58-1.7 3.74-2.31-1.92-.46-4.1-.88-6.51-1.17-2.52-.3-4.83-.4-6.88-.38 2.42 2.21 4.38 4.64 5.87 6.96z"
+        fillRule="evenodd"
+        transform="matrix(.26458 0 0 .26458 -.189 -.253)"
+      />
+      <path
+        d="M74.58 5.55s3.24 9.95 3.35 15.04c-3.93.93-7.4 2.31-11.21 5.56 2.08 1.04 3.93 2.31 5.67 3.82 1.85 1.62 3.58 2.31 6.01 1.16 1.39-.93 9.13-8.91 9.94-9.95 1.85-1.97 1.39-5.21-.58-6.71-4.86-4.51-13.18-8.91-13.18-8.91ZM2.82 37.77c3.47-2.31 6.94-3.82 10.41-4.63-1.5-3.12-2.54-6.71-2.77-10.88C7.11 27 4.45 32.33 2.83 37.77zM28.59 32.72c-1.16-2.2-2.66-5.79-3.47-10.18-3.12-.69-6.59-1.04-10.64-.46.23 4.05 1.39 7.52 2.89 10.53 4.62-.69 8.56-.35 11.22.12z"
+        fillRule="evenodd"
+        transform="matrix(.26458 0 0 .26458 -.189 -.253)"
+      />
+    </svg>
+  );
+}
+
+/** Pixi (prefix.dev) logo mark. */
+function PixiIcon({ className, ...props }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 27.4 40.2"
+      fill="currentColor"
+      className={className}
+      {...props}
+    >
+      <path d="M27.116 3.67449C27.0374 1.63273 25.7268 0.270764 23.633 0.19141C16.9597-0.0609578 10.2854-0.0667476 3.61182 0.19175C1.56495 0.270764 0.211498 1.63273 0.128738 3.67449C0.0507459 5.60828 0.00647096 8.27738 0 9.98946C0 10.843 0.666168 11.488 1.56086 11.488C2.04414 11.488 2.46169 11.2956 2.74845 10.988C2.7539 10.985 2.76174 10.9846 2.76548 10.9802C3.03897 10.6791 3.2348 10.3079 3.50385 10.001C3.83217 9.62675 4.21021 9.28515 4.63219 9.0195C5.45945 8.49842 6.37151 8.20655 7.44535 8.20655C10.2694 8.20655 12.5673 10.2745 12.5673 13.3496C12.5673 16.4638 10.3297 18.5679 7.27779 18.5679C5.44514 18.5679 3.82195 17.7733 2.92351 16.2333C2.91193 16.2132 2.89695 16.1978 2.88469 16.1791C2.8789 16.1709 2.87311 16.1631 2.86732 16.1549C2.83019 16.1028 2.78932 16.0558 2.74505 16.0139C2.45862 15.7088 2.0421 15.518 1.5612 15.518C0.777537 15.518 0.169607 16.0132 0.0306519 16.7094C0.00919558 16.7714 0 16.8555 0.000340577 17.0162C0.00613038 18.7246 0.0527894 21.6614 0.129079 23.6953C0.166542 24.6952 0.572169 25.6696 1.34017 26.3269C2.21647 27.0772 3.21028 27.0776 4.28207 27.272C4.6516 27.3391 5.02215 27.4587 5.30585 27.7148C5.7159 28.0853 5.86712 28.6974 5.73531 29.2338C5.59125 29.8185 5.17268 30.2007 4.69996 30.5327C4.26232 30.8403 3.85874 31.1689 3.5168 31.5837C2.78694 32.4686 2.4089 33.5853 2.4089 34.7293C2.4089 37.8435 4.56986 40.0764 7.72326 40.0764C10.8375 40.0764 13.0836 37.9808 13.0836 35.0426C13.0836 33.8976 12.7699 32.7509 12.0912 31.8191C11.7683 31.376 11.3708 30.9935 10.9213 30.6809C10.47 30.3672 10.0136 30.1349 9.78409 29.5989C9.65433 29.2954 9.6104 28.9531 9.68362 28.6296C10.0068 27.1981 11.6052 27.3551 12.7233 27.3592C14.2909 27.365 15.8586 27.3579 17.426 27.3364C19.4956 27.3081 21.565 27.2557 23.6333 27.178C25.5899 27.1045 27.0377 25.6999 27.1164 23.695C27.3783 17.0217 27.3735 10.3474 27.1164 3.67381Z" />
+    </svg>
+  );
+}
+
+type Runtime = "python" | "deno";
+type Manager = "uv" | "conda" | "pixi";
+
+interface RuntimeBadgeProps {
+  /** Notebook runtime. Drives the leading icon, label, and pill color. */
+  runtime?: Runtime;
+  /** Environment manager. Renders its logo after a "/" separator. */
+  manager?: Manager;
+  /** Show the runtime-peer indicator (the ServerCog after a "/"). */
+  peers?: boolean;
+  className?: string;
+}
+
+/**
+ * The runtime / package-manager pill from the nteract notebook toolbar, as a
+ * presentational badge for use in prose. Ported from the inline badge in
+ * `NotebookCommandToolbar`: a colored pill with the language mark and label,
+ * then the environment-manager logo (uv / conda / pixi) after a separator.
+ */
+export function RuntimeBadge({
+  runtime = "python",
+  manager,
+  peers,
+  className,
+}: RuntimeBadgeProps) {
+  const isDeno = runtime === "deno";
+
+  return (
+    <span
+      data-runtime={runtime}
+      data-env-manager={manager}
+      className={cn(
+        "inline-flex items-center gap-1 rounded px-1.5 py-0.5 align-middle text-[10px] font-medium leading-none",
+        isDeno
+          ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
+          : "bg-blue-500/10 text-blue-600 dark:text-blue-400",
+        className,
+      )}
+    >
+      {isDeno ? (
+        <DenoIcon className="size-3" />
+      ) : (
+        <PythonIcon className="size-3" />
+      )}
+      <span>{isDeno ? "Deno" : "Python"}</span>
+      {manager ? (
+        <>
+          <span className="opacity-40">/</span>
+          {manager === "uv" ? (
+            <UvIcon className="size-2 text-fuchsia-600 dark:text-fuchsia-400" />
+          ) : null}
+          {manager === "conda" ? (
+            <CondaIcon className="size-2.5 text-emerald-600 dark:text-emerald-400" />
+          ) : null}
+          {manager === "pixi" ? (
+            <PixiIcon className="size-2.5 text-amber-600 dark:text-amber-400" />
+          ) : null}
+        </>
+      ) : null}
+      {peers ? (
+        <>
+          <span className="opacity-40">/</span>
+          <ServerCog className="size-2.5" aria-hidden="true" />
+        </>
+      ) : null}
+    </span>
+  );
+}

--- a/components/video.tsx
+++ b/components/video.tsx
@@ -1,0 +1,41 @@
+import { cn } from "@/lib/utils";
+
+interface VideoProps {
+  src: string;
+  /** Short caption rendered beneath the frame. */
+  caption?: string;
+  /** Optional still shown before the clip loads. */
+  poster?: string;
+  className?: string;
+}
+
+/**
+ * Looping, muted, autoplaying clip for inline product demos — the motion
+ * equivalent of an image in the prose. Framed to match the changelog hero
+ * video: a bordered box on the page rule. Controls stay available so a
+ * reader can pause or scrub.
+ */
+export function Video({ src, caption, poster, className }: VideoProps) {
+  return (
+    <figure className={cn("my-10", className)}>
+      <div className="overflow-hidden border border-[var(--rule)]">
+        <video
+          src={src}
+          poster={poster}
+          autoPlay
+          muted
+          loop
+          playsInline
+          controls
+          preload="metadata"
+          className="w-full"
+        />
+      </div>
+      {caption ? (
+        <figcaption className="mt-2 font-mono text-[11px] uppercase tracking-widest text-[var(--muted)]">
+          {caption}
+        </figcaption>
+      ) : null}
+    </figure>
+  );
+}

--- a/content/changelog/2.6.mdx
+++ b/content/changelog/2.6.mdx
@@ -17,6 +17,8 @@ tags:
   - "markdown"
 published: true
 githubReleaseUrl: "https://github.com/nteract/nteract/releases/tag/v2.6.0-stable.202606251403"
+heroVideo: "https://img.runt.run/2026/06/2.6-outline-editing.mp4"
+heroVideoPoster: "https://img.runt.run/2026/06/2.6-hero-poster.png"
 ---
 
 This release makes me very proud. I redesigned the cell chrome, created a markdown pipeline, and brought back everyone's favorite ToC. The focus in 2.5 was around outputs: navigable tracebacks, explorable DataFrames, and keeping secrets out of the outputs. In the 2.6 release we're turning back to document operations. Long notebooks get more structure with a dedicated table of contents/outline, tooling like package selection moves into a dedicated rail with room for more, and additional editing controls.
@@ -31,8 +33,6 @@ This release makes me very proud. I redesigned the cell chrome, created a markdo
 />
 
 Click the outline view in the rail to hop between markdown segments and image outputs within your notebooks.
-
-{/* Show another outline that changes as you edit markdown headings */}
 
 The outline shows your heading hierarchy and updates live as you edit.
 

--- a/content/changelog/2.6.mdx
+++ b/content/changelog/2.6.mdx
@@ -47,8 +47,8 @@ Can we all agree that this is not how we should install dependencies in a notebo
 Not everyone realized you could click <RuntimeBadge runtime="python" manager="uv" /> to install deps into an nteract notebook. To make this more clear, packaging has been moved into the new rail. You can manage dependencies directly.
 
 <Video
-  src="https://img.runt.run/2026/06/2.6-packaging-v2.mp4"
-  poster="https://img.runt.run/2026/06/2.6-packaging-v2.png"
+  src="https://img.runt.run/2026/06/2.6-packaging-v3.mp4"
+  poster="https://img.runt.run/2026/06/2.6-packaging-v3.png"
   caption="Adding a package from the rail, no notebook cell required"
 />
 
@@ -88,8 +88,8 @@ After landing the rail work, it was clear there was opportunity to create cleare
 ### Changing cell type
 
 <Video
-  src="https://img.runt.run/2026/06/2.6-change-cell-type-v2.mp4"
-  poster="https://img.runt.run/2026/06/2.6-change-cell-type-v2.png"
+  src="https://img.runt.run/2026/06/2.6-change-cell-type-v3.mp4"
+  poster="https://img.runt.run/2026/06/2.6-change-cell-type-v3.png"
   caption="Switching a cell between code and Markdown in place"
 />
 

--- a/content/changelog/2.6.mdx
+++ b/content/changelog/2.6.mdx
@@ -17,8 +17,8 @@ tags:
   - "markdown"
 published: true
 githubReleaseUrl: "https://github.com/nteract/nteract/releases/tag/v2.6.0-stable.202606251403"
-heroVideo: "https://img.runt.run/2026/06/2.6-outline-editing.mp4"
-heroVideoPoster: "https://img.runt.run/2026/06/2.6-hero-poster.png"
+heroVideo: "https://img.runt.run/2026/06/2.6-outline-editing-cursor.mp4"
+heroVideoPoster: "https://img.runt.run/2026/06/2.6-hero-poster-cursor.png"
 ---
 
 This release makes me very proud. I redesigned the cell chrome, created a markdown pipeline, and brought back everyone's favorite ToC. The focus in 2.5 was around outputs: navigable tracebacks, explorable DataFrames, and keeping secrets out of the outputs. In the 2.6 release we're turning back to document operations. Long notebooks get more structure with a dedicated table of contents/outline, tooling like package selection moves into a dedicated rail with room for more, and additional editing controls.
@@ -74,7 +74,7 @@ After landing the rail work, it was clear there was opportunity to create cleare
 <LightboxImage
   src="https://img.runt.run/2026/06/2.6-hidden-cells.png"
   alt="Hidden cells with clearer reveal language"
-  className="my-10 w-full border border-[var(--rule)]"
+  className="my-10 w-full"
 />
 
 ### Motion on execution

--- a/content/changelog/2.6.mdx
+++ b/content/changelog/2.6.mdx
@@ -4,8 +4,8 @@ date: "2026-06-25T00:00:00Z"
 coversVersions:
   - "2.6.0"
 dateLabel: "June 25, 2026"
-title: "Outline, Editing Controls, and Widget State"
-summary: "nteract 2.6 tightens the desktop notebook: a left-rail outline, package panels that stay out of the notebook body, stronger widget state restoration, better Markdown and TeX rendering, first-class code/Markdown cell conversion, and a setting to disable automatic formatting."
+title: "Outlines of the Railway"
+summary: "nteract 2.6 polishes design with a left rail, outlines, packaging selection, and improved markdown + TeX rendering."
 highlights:
   - "Navigate long notebooks from a left-rail outline"
   - "Manage packages from the rail without turning dependencies into notebook cells"
@@ -13,37 +13,12 @@ highlights:
   - "Disable automatic code formatting when exact source layout matters"
   - "Keep widget state and rich output renders steadier across sessions"
 tags:
-  - "notebook"
   - "design"
-  - "editing"
-  - "packages"
-  - "widgets"
+  - "rail"
   - "markdown"
 published: true
-# githubReleaseUrl: "https://github.com/nteract/nteract/releases/tag/v2.6.0-stable.TODO"
-# heroImage: "https://img.runt.run/TODO/2.6-hero.png"
-# heroVideo: "https://img.runt.run/TODO/2.6-demo.mp4"
+githubReleaseUrl: "https://github.com/nteract/nteract/releases/tag/v2.6.0-stable.202606251403"
 ---
-
-{/*
-Release prep notes, refreshed from /home/ubuntu/projects/nteract on 2026-06-23.
-
-Base: v2.5.1-stable.202605261941
-Base commit: 4867b005ac89d1ce28775c27a33f379da0d0f50e
-Head: release/2.6.0
-Head commit: 3376f1e865a9d19d32507cb90718084b3a2fa1c3
-Range: 4867b005ac89d1ce28775c27a33f379da0d0f50e..3376f1e865a9d19d32507cb90718084b3a2fa1c3
-First-parent commits at draft time: 678
-All commits at draft time: 903
-
-Before publishing:
-- Replace the draft date with the final stable release date.
-- Replace coversVersions with the final stable and patch versions.
-- Add the final githubReleaseUrl.
-- Add the 2.6 hero image and any demo videos.
-- Refresh the range against the final stable tag if it differs from the release branch head.
-- Replace the draft technical changelog with the generated final changelog.
-*/}
 
 2.6 is a notebook ergonomics release.
 
@@ -53,8 +28,6 @@ The theme is simple: the notebook should stay centered, and the workspace around
 
 ## Find your place in long notebooks
 
-{/* TODO: add a screenshot or short clip of the left rail switching between outline and package panels. */}
-
 Long notebooks now get an outline in the left rail.
 
 Headings become landmarks. You can skim the document structure, jump between sections, and keep the cell body focused on the work itself. The outline also keeps improving as Markdown rendering moves through the shared Rust/WASM path, so anchors and headings are not a separate, fragile interpretation of the document.
@@ -63,8 +36,6 @@ This is the clearest new shape in 2.6: the notebook body is for cells, and the r
 
 ## Packages belong beside the notebook
 
-{/* TODO: add a focused media capture of package management in the rail. */}
-
 Managing packages is part of notebook work. It is also not the notebook itself.
 
 2.6 moves package management into the same rail model as the outline. Package state stays attached to the notebook, but dependency management no longer needs to compete with prose, code, and output for space in the main document. You can see what the notebook depends on, adjust it, and get back to the cells faster.
@@ -72,8 +43,6 @@ Managing packages is part of notebook work. It is also not the notebook itself.
 This is one of those changes that matters most after repetition: the environment is still visible, but it stops feeling like another cell-shaped interruption.
 
 ## Widgets remember more
-
-{/* TODO: add a before/after widget state demo if we have a good one. */}
 
 Widget state is the sleeper feature in this release.
 
@@ -91,8 +60,6 @@ The Markdown path is also moving through the Rust/WASM markdown engine. Users do
 
 ## The notebook shell settles down
 
-{/* TODO: add a short clip that shows the new cell affordances and animations in motion. */}
-
 There is a lot of design work in 2.6, and it should not disappear under the word "polish."
 
 The notebook shell has clearer affordances for what you can do, what state a cell is in, and where the next action lives. Hidden cells use clearer language. Completed cells get quieter. Structure edits gate themselves on host support. The rail can carry more responsibility, so the notebook body can stay focused on cells and output.
@@ -103,8 +70,6 @@ The result is an app that asks you to re-orient less often.
 
 ## Change the cell you already have
 
-{/* TODO: capture the cell context menu showing the change-type entry. */}
-
 A cell should not be stuck as the type you first made it.
 
 2.6 makes switching a cell between code and Markdown a first-class move. Right-click a cell, or use the main menu, and change its type in place. That covers the everyday notebook loop: write a thought in Markdown, turn a scratch cell back into code, or correct the type without deleting and recreating anything.
@@ -113,34 +78,22 @@ The switch is an edit on the cell itself, so its place in the notebook and anyth
 
 ## Formatting becomes a choice
 
-{/* TODO: capture the Disable automatic formatting setting. */}
-
 nteract can tidy code on its way through the notebook: `ruff` for Python and `deno fmt` for the rest. Some people love that. Some people want their source left exactly as written.
 
 2.6 adds **Disable automatic formatting** in Settings. Auto-formatting stays on by default for the people who want it, but the editor no longer insists on rewriting code when exact layout matters. This closes a long-standing request ([#3795](https://github.com/nteract/nteract/issues/3795)).
 
 ## A quiet comments preview
 
-{/* TODO: optional small capture of the Enable Comments UI flag, or leave it for the 2.7 splash. */}
-
 There is one more thing in 2.6, and it is intentionally quiet. Turn on **Enable Comments UI** in Settings, under Feature Flags, and you can try the new notebook commenting surface: select code or rendered Markdown, leave a note, and reply in the discussion rail.
 
 The preview ships off by default. 2.6 gives early testers a way to try the surface before the public 2.7 commenting release, where anchoring, authorship, and the full discussion model get their own introduction.
 
-## Draft technical changelog
+## Technical changelog
 
 <details>
-<summary>Current draft range summary</summary>
+<summary>Selected commits since 2.5.1</summary>
 
-This section is a prep scaffold, not the final generated changelog.
-
-Current source range:
-
-```text
-4867b005ac89d1ce28775c27a33f379da0d0f50e..3376f1e865a9d19d32507cb90718084b3a2fa1c3
-```
-
-The range currently contains 678 first-parent commits and 903 total commits since `v2.5.1-stable.202605261941`.
+Highlights from the `v2.5.1-stable.202605261941` → `v2.6.0-stable.202606251403` range. Not exhaustive; see the [release notes](https://github.com/nteract/nteract/releases/tag/v2.6.0-stable.202606251403) for the full list.
 
 ### Rail, outline, and packages
 

--- a/content/changelog/2.6.mdx
+++ b/content/changelog/2.6.mdx
@@ -4,17 +4,17 @@ date: "2026-06-10T00:00:00Z"
 coversVersions:
   - "2.6.0"
 dateLabel: "Draft - June 10, 2026"
-title: "Hosted Notebooks, Workstations, and One Notebook Shell"
-summary: "The nteract 2.6 draft brings hosted notebooks closer to the desktop app: shared NotebookView surfaces, owner-run cloud execution, workstation compute, faster hosted outputs, and cleaner MCP resources."
+title: "Outline Rail, Package Management, Widget State"
+summary: "The nteract 2.6 draft focuses the notebook workspace: a left rail with outline and packages, widget state that survives more of your work, and Markdown improvements including bare TeX rendering."
 highlights:
-  - "Hosted notebooks can be shared, edited, and executed through owner-controlled runtime peers"
-  - "Desktop and cloud notebooks now converge on the same NotebookView shell, rail, capabilities, and actor model"
-  - "Publishing, widgets, output frames, Sift, and MCP resources got faster and harder to break"
+  - "The left rail now carries the notebook outline and package management"
+  - "Widget state is saved and restored more reliably across notebook sessions"
+  - "Markdown rendering is backed by the Rust engine and now handles bare TeX environments"
 tags:
-  - "cloud"
-  - "workstations"
   - "notebook"
-  - "mcp"
+  - "packages"
+  - "widgets"
+  - "markdown"
 published: false
 # githubReleaseUrl: "https://github.com/nteract/nteract/releases/tag/v2.6.0-stable.TODO"
 # heroImage: "https://img.runt.run/TODO/2.6-hero.png"
@@ -35,79 +35,57 @@ All commits at draft time: 666
 Before publishing 2.6, refresh the clone, replace the head commit with the final stable tag commit, regenerate the technical changelog, and update coversVersions/githubReleaseUrl/media.
 */}
 
-2.6 is the release where the browser notebook stops feeling like a read-only postcard from the desktop app.
+2.6 is the release where the notebook gets more shape around the work you are already doing.
 
-This one is about making the same notebook surface show up in more places: local files, hosted rooms, shared links, runtime peers, workstation compute, and the agents that want to read or drive the notebook without inventing a second copy of it.
+2.5 made outputs feel richer: navigable tracebacks, explorable DataFrames, and secrets that stay out of notebook output. 2.6 is quieter, but it is the kind of quiet that matters after a few hours in the same notebook. Navigation moves closer. Packages stop competing with the page. Widgets remember more. Markdown behaves more like a document.
 
-I've wanted nteract cloud notebooks to feel less like "publish a snapshot" and more like "keep working in the same room." This release is the big step in that direction.
+This is a notebook ergonomics release.
 
-## Hosted notebooks you can work in
+## The rail has a job now
 
-{/* TODO: add a short video showing a hosted notebook moving between viewer/editor modes, sharing controls, and live output updates. */}
+{/* TODO: add a screenshot or short clip of the left rail switching between outline and package panels. */}
 
-Hosted notebooks now have real room mechanics behind them. Owners can share notebooks, grant edit access, accept authenticated viewers, and keep browser sessions attached without turning every link into a one-off artifact.
+The left rail now carries the notebook outline.
 
-The cloud app learned about app sessions, owner-gated sharing controls, edit access requests, invite storage, friendlier presence labels, and hosted widget state that survives more of the weird browser edges. The point is boring in the best way: a hosted notebook should feel like a notebook you can keep using.
+That sounds small until you are in a long notebook and every heading has become a landmark. Instead of scrolling by vibes, you can skim the document structure, jump between sections, and keep the notebook body focused on the cells themselves.
 
-## Run it from the cloud, keep the runtime yours
+The rail also gives package management a better home. Package state belongs near the notebook, but it does not need to live in the notebook body. Moving package management into the rail makes the environment feel attached to the work without turning dependency management into another cell-shaped distraction.
 
-{/* TODO: add a demo clip of starting workstation compute from the hosted toolbar. */}
+I like this direction because it makes nteract feel less like an editor with a notebook inside it and more like a notebook with the right surrounding instruments.
 
-2.6 starts connecting hosted notebooks to real compute instead of pretending the viewer is the runtime.
+## Package management moved out of the way
 
-Runtime peers can attach to hosted rooms, accept execution intent, reconnect, re-auth, and publish their state back to the room. Workstations show up in the document rail and can be started from the hosted toolbar. There is a one-liner workstation install path in the current range, plus Anaconda API key support for the hosted side of the flow.
+{/* TODO: add a focused media capture of package management in the rail. */}
 
-This is the shape I want for cloud notebooks: the browser owns the collaboration and sharing surface, but the runtime stays explicit. You can see when compute is offline, when a peer is attached, and when a room is waiting on a runtime instead of guessing.
+Managing packages is part of notebook work. It is also not the notebook itself.
 
-## One NotebookView
+The 2.6 rail work makes package panels and summaries feel like part of the workspace chrome instead of a one-off interruption. You can keep track of the environment, see what the notebook depends on, and get back to the cells faster.
 
-The desktop app and hosted cloud used to look related, but too much of the notebook chrome was duplicated. 2.6 cuts that down.
+This is the same philosophy behind the rest of the rail: outline, packages, runtime, search, and other notebook-adjacent tools should be available without taking over the notebook.
 
-The notebook view now shares more of its shell: the rail, capability model, headers, host notices, package summaries, search, environment panels, hidden-cell affordances, output focus, and execution language. That sounds internal, but it changes how the app feels. The cloud notebook and the desktop notebook are now arguing less about what a notebook is.
+## Widgets remember more
 
-You can see it in smaller things too: read-only markdown still navigates, editor controls gate themselves on host capabilities, execution status takes up less visual noise, and the left rail finally has enough structure to carry outline, packages, runtime, workstation, and search surfaces without becoming a junk drawer.
+{/* TODO: add a before/after widget state demo if we have a good one. */}
 
-## Markdown grew up
+Widget state is the sleeper feature in this release.
 
-Markdown is no longer just a React-side preview bolted to cells.
+Some of the pressure for this came from work on hosted notebooks, but the feature matters on the desktop too. Once a widget becomes part of how you explore a notebook, it is not enough to replay the code and hope the UI lands in the same place. Sliders, progress, controls, and comm-backed state need to survive more of the notebook's real life.
 
-This range moves markdown through the Rust/WASM markdown engine, adds richer document typography, fixes bare TeX environments, restores double-click editing, keeps document frames selectable, and uses markdown engine anchors for notebook outlines.
+2.6 saves live widget state metadata more reliably and moves widget comm state into a clearer document path. The user-facing version is simple: widgets should feel less temporary.
 
-That matters for hosted notebooks because markdown is the bridge between "notebook as code scratchpad" and "notebook as report." If the cloud view is going to be a real shared document, markdown has to be stable, navigable, and pleasant to read.
+## Bare TeX works
 
-## Outputs and widgets got more durable
+Markdown got more serious in 2.6.
 
-2.5 made outputs more explorable. 2.6 keeps pushing on the part where outputs must survive being published, framed, shared, cached, replayed, and read by tools.
+Bare TeX environments now project as math instead of sitting there like slightly suspicious plain text. If you write a notebook as a document, not just as a pile of code cells, that matters. Equations should read as equations.
 
-Widgets now save more live metadata. Progress widgets hydrate correctly in hosted views. Sift picked up image thumbnails and image navigation. Engaged Sift frames behave better with scroll boundaries. Output frames respect host frame domains, hosted viewers preload the sidecars they need, and blob metadata is harder to corrupt when the same output shows up twice.
+The Markdown path is also moving through the Rust/WASM markdown engine. Users probably do not need to care about the engine by name, but they should care about what it unlocks: steadier parsing, shared behavior, better anchors for outlines, and a Markdown cell that can carry more of the document experience without special cases.
 
-There is also a lot of unglamorous repair here: nested Arrow blobs, widget comm blobs, published output refs, first-paint theme seeding, direct output document transforms, and cached renderer assets. That is the work that makes a notebook output feel boringly present when it leaves your machine.
+## A better notebook shell
 
-## Hosted publishing is getting faster
+A lot of the 2.6 work sits just below the surface: shared rail pieces, shell capabilities, quieter execution affordances, better hidden-cell language, shared package summaries, and a more consistent NotebookView.
 
-{/* TODO: add a before/after clip or timing capture for hosted output hydration. */}
-
-The viewer path got a serious round of performance work.
-
-Hosted notebooks now defer and stage more of the expensive output work: lazy output frame mounting, progressive output hydration, runtime WASM preloads, Sift WASM preloads, sidecar renderer assets, hosted output blob caching, viewer CSS splitting, and incremental live runtime projections.
-
-The user-facing version is simple: shared notebooks should load the notebook first, then get richer as the expensive pieces arrive. No one should wait for every widget, frame, stylesheet, and blob before reading the first cell.
-
-## MCP reads the notebook, not a shadow notebook
-
-MCP and agent surfaces are quieter and more notebook-native in 2.6.
-
-Cell reads prefer resources. Client display names are canonicalized. Generated icons are advertised. Proxy recovery messages are more install-aware. The notebook tool bridge is exposed from `runt`, and the hosted/browser runtime work gives agents a clearer route into the same notebook state a human sees.
-
-That is the part I care about most: tools should not need a parallel notebook model. They should read cells, outputs, identities, and runtime state from the same documents the app is already using.
-
-## Under the floorboards
-
-There is a lot of floorboard work in this range.
-
-Runtime state documents now carry identity. Widget comm state is split into `CommsDoc`. Autosave is more careful about stale rooms and empty-room overwrites. Fresh notebook seeding is daemon-owned. Connection status is observable. Local-first persistence gets a `notebookDocChanged$` signal. Runtimed has a test kernel and a clearer kernel dispatch enum. Sync peer egress lanes are split and classified.
-
-That is not a flashy list, but it is the kind of foundation this app needs before the same notebook can move between local editing, hosted viewing, shared execution, and agent tooling without losing the plot.
+That may sound like internal plumbing, but it shows up in the app as fewer weird edges. Read-only markdown still navigates. Structure edits gate themselves on host support. The rail can carry more responsibility. The notebook body gets to stay the notebook body.
 
 ## Things to finish before publishing
 
@@ -117,7 +95,7 @@ That is not a flashy list, but it is the kind of foundation this app needs befor
 - Add the 2.6 hero image and any demo videos.
 - Refresh the commit range comment against the final stable tag.
 - Regenerate or paste the final technical changelog.
-- Trim any sections that are too implementation-heavy after the final release shape is clear.
+- Trim any sections that still read too implementation-heavy after the release shape is final.
 
 ## Working technical changelog
 
@@ -134,80 +112,42 @@ Current source range:
 
 The range currently contains 441 first-parent commits and 666 total commits since `v2.5.1-stable.202605261941`.
 
-### Hosted notebooks and sharing
+### Rail, outline, and packages
 
-- add hosted sharing controls ([cbe800f](https://github.com/nteract/nteract/commit/cbe800f4))
-- add hosted edit access requests ([67d0fcd](https://github.com/nteract/nteract/commit/67d0fcda))
-- grant editors full cell editing in hosted rooms ([956cce9](https://github.com/nteract/nteract/commit/956cce97))
-- render hosted notebooks through `NotebookView` ([2723268](https://github.com/nteract/nteract/commit/27232684))
-- bootstrap notebook home with app sessions ([5162237](https://github.com/nteract/nteract/commit/51622379))
-- polish notebook home and workstation panel ([5cb944c](https://github.com/nteract/nteract/commit/5cb944c1))
-- gate sharing controls to owners ([790b759](https://github.com/nteract/nteract/commit/790b7591))
-
-### Runtime peers and workstations
-
-- add `runt publish` helper ([39c7acc](https://github.com/nteract/nteract/commit/39c7acc5))
-- accept Anaconda API keys ([61ccd18](https://github.com/nteract/nteract/commit/61ccd186))
-- add preview OIDC login ([4444f9f](https://github.com/nteract/nteract/commit/4444f9fc))
-- add cloud runtime lifecycle ([809cf01](https://github.com/nteract/nteract/commit/809cf01e))
-- add transport-agnostic `runtime_agent` and cloud WebSocket transport ([9c87bd0](https://github.com/nteract/nteract/commit/9c87bd01))
-- add daemon workstation endpoint ([8660705](https://github.com/nteract/nteract/commit/86607050))
-- register hosted workstations ([b3b10f5](https://github.com/nteract/nteract/commit/b3b10f59))
-- project workstation launch contract ([c100d41](https://github.com/nteract/nteract/commit/c100d414))
-- start workstation compute from the toolbar ([ddbaa4e](https://github.com/nteract/nteract/commit/ddbaa4e7))
-
-### Notebook shell convergence
-
-- add shared notebook rail shell ([5b365b8](https://github.com/nteract/nteract/commit/5b365b8b))
 - add contextual outline tree ([db4b61a](https://github.com/nteract/nteract/commit/db4b61ac))
 - add left rail panels ([f07b528](https://github.com/nteract/nteract/commit/f07b5286))
-- add capability-scoped document header ([fdf13aa](https://github.com/nteract/nteract/commit/fdf13aae))
-- drive `NotebookView` from shell capabilities ([8af8135](https://github.com/nteract/nteract/commit/8af81352))
-- refine hidden and output surfaces ([5b5fda8](https://github.com/nteract/nteract/commit/5b5fda8f))
-- share runtime command projection ([90cdb05](https://github.com/nteract/nteract/commit/90cdb057))
-- add connection status and local-first persistence signals ([50187ab](https://github.com/nteract/nteract/commit/50187ab2))
+- add shared notebook rail shell ([5b365b8](https://github.com/nteract/nteract/commit/5b365b8b))
+- polish notebook rail outline and packages ([c350f5c](https://github.com/nteract/nteract/commit/c350f5cf))
+- split package manager panels ([aaa65fd](https://github.com/nteract/nteract/commit/aaa65fd2))
+- share package summary surfaces ([b41296c](https://github.com/nteract/nteract/commit/b41296c0))
+- document package manager surfaces ([163f447](https://github.com/nteract/nteract/commit/163f447c))
 
-### Markdown, outputs, and widgets
+### Widget state
 
-- add traceback frame navigation ([b96f758](https://github.com/nteract/nteract/commit/b96f7584))
-- add Sift image thumbnail viewer ([f8a308e](https://github.com/nteract/nteract/commit/f8a308ed))
-- add Sift image viewer navigation ([3fd5852](https://github.com/nteract/nteract/commit/3fd5852f))
-- project markdown through Rust WASM ([5d4682e](https://github.com/nteract/nteract/commit/5d4682e1))
-- refine document typography ([e113ccb](https://github.com/nteract/nteract/commit/e113ccb2))
-- keep document frames selectable ([449315f](https://github.com/nteract/nteract/commit/449315fd))
+- save live widget state metadata ([644933e](https://github.com/nteract/nteract/commit/644933e8))
 - split widget comm state into `CommsDoc` ([13a5fe2](https://github.com/nteract/nteract/commit/13a5fe23))
 - project `CommsDoc` widget state to Python ([54339c1](https://github.com/nteract/nteract/commit/54339c12))
-- save live widget state metadata ([644933e](https://github.com/nteract/nteract/commit/644933e8))
+- hydrate widget progress views ([f640db7](https://github.com/nteract/nteract/commit/f640db7c))
+- resolve widget comm blobs ([d50887c](https://github.com/nteract/nteract/commit/d50887ca))
+- show stale widget snapshots ([a9bbc54](https://github.com/nteract/nteract/commit/a9bbc54e))
 
-### Performance and hosted viewer loading
+### Markdown and TeX
 
-- preload Sift WASM for live views ([cf8172a](https://github.com/nteract/nteract/commit/cf8172a3))
-- hydrate hosted outputs progressively ([d16326e](https://github.com/nteract/nteract/commit/d16326e1))
-- load renderer from sidecar assets ([98663df](https://github.com/nteract/nteract/commit/98663df4))
-- defer supplemental viewer CSS ([a6e94b2](https://github.com/nteract/nteract/commit/a6e94b2e))
-- stage async output resolution ([8f32259](https://github.com/nteract/nteract/commit/8f322592))
-- lazy mount output frames ([91f3977](https://github.com/nteract/nteract/commit/91f3977d))
-- cache hosted output blobs ([5499951](https://github.com/nteract/nteract/commit/5499951d))
-- project live runtime updates incrementally ([679c6ae](https://github.com/nteract/nteract/commit/679c6ae2))
-- coalesce concurrent text-blob fetches ([f908f43](https://github.com/nteract/nteract/commit/f908f431))
+- project Markdown through Rust WASM ([5d4682e](https://github.com/nteract/nteract/commit/5d4682e1))
+- project bare TeX environments as math ([70d1006](https://github.com/nteract/nteract/commit/70d10061))
+- restore preview double-click editing ([5d337e7](https://github.com/nteract/nteract/commit/5d337e77))
+- keep document frames selectable ([449315f](https://github.com/nteract/nteract/commit/449315fd))
+- use markdown engine anchors for notebook outline ([9344e01](https://github.com/nteract/nteract/commit/9344e010))
+- refine document typography ([e113ccb](https://github.com/nteract/nteract/commit/e113ccb2))
 
-### MCP, agents, and tooling
+### Notebook shell and ergonomics
 
-- canonicalize MCP client display names ([c9f24ae](https://github.com/nteract/nteract/commit/c9f24ae3))
-- advertise generated MCP icons ([b6b6db7](https://github.com/nteract/nteract/commit/b6b6db78))
-- prefer resources for cell reads ([689034e](https://github.com/nteract/nteract/commit/689034e9))
-- expose notebook tool bridge ([497a3fa](https://github.com/nteract/nteract/commit/497a3fa7))
-- make proxy recovery messages install-aware ([c84481d](https://github.com/nteract/nteract/commit/c84481d6))
-- make Codex notebook MCP installs distinct ([1823167](https://github.com/nteract/nteract/commit/18231676))
-
-### Safety and foundations
-
-- add runtime state document identity ([e385d80](https://github.com/nteract/nteract/commit/e385d806))
-- seed runtime state document identity in rooms ([2cdcd22](https://github.com/nteract/nteract/commit/2cdcd225))
-- gate hosted runtime state writes ([3573305](https://github.com/nteract/nteract/commit/35733050))
-- do not autosave an empty room over a non-empty notebook file ([7c2a255](https://github.com/nteract/nteract/commit/7c2a255b))
-- make fresh notebook seeding daemon-owned ([2d1da4a](https://github.com/nteract/nteract/commit/2d1da4a3))
-- refuse stale autosaves and write `.ipynb` atomically ([7c36d0f](https://github.com/nteract/nteract/commit/7c36d0fc))
-- add `TestKernel` and kernel dispatch enum ([dc77f16](https://github.com/nteract/nteract/commit/dc77f16b))
+- add capability-scoped document header ([fdf13aa](https://github.com/nteract/nteract/commit/fdf13aae))
+- drive `NotebookView` from shell capabilities ([8af8135](https://github.com/nteract/nteract/commit/8af81352))
+- gate run controls on host-neutral runtime availability ([4cb2b76](https://github.com/nteract/nteract/commit/4cb2b766))
+- refine hidden and output surfaces ([5b5fda8](https://github.com/nteract/nteract/commit/5b5fda8f))
+- soften hidden cell reveal rows ([5477469](https://github.com/nteract/nteract/commit/54774693))
+- quiet completed cell status ([335f0ab](https://github.com/nteract/nteract/commit/335f0ab9))
+- keep hidden cell keyboard navigation moving ([f2555da](https://github.com/nteract/nteract/commit/f2555da2))
 
 </details>

--- a/content/changelog/2.6.mdx
+++ b/content/changelog/2.6.mdx
@@ -117,6 +117,14 @@ nteract can tidy code on its way in: `ruff` for Python, `deno fmt` for the rest.
 
 2.6 adds a setting to turn automatic reformatting off. When it is off, the notebook stops rewriting code you did not ask it to touch. Auto-format stays the default for the people who like it, but it is no longer something the editor insists on. This closes a long-standing request ([#3795](https://github.com/nteract/nteract/issues/3795)).
 
+## A quiet comments preview
+
+{/* TODO: optional small capture of the Enable Comments UI flag, or leave it for the 2.7 splash. */}
+
+There is one more thing in 2.6, and it is on purpose that you have to go looking for it. Turn on **Enable Comments UI** in Settings, under Feature Flags, and you can comment on a notebook: select a bit of code or rendered Markdown, leave a note, and reply in a discussion rail.
+
+It ships off by default. 2.6 is the soft preview for people who want to kick the tires early. The real introduction, anchoring that survives edits, author identity for the people and agents in a notebook, and the whole discussion model, is the 2.7 release.
+
 ## Things to finish before publishing
 
 - Replace the draft date with the final release date.

--- a/content/changelog/2.6.mdx
+++ b/content/changelog/2.6.mdx
@@ -47,8 +47,8 @@ Can we all agree that this is not how we should install dependencies in a notebo
 Not everyone realized you could click <RuntimeBadge runtime="python" manager="uv" /> to install deps into an nteract notebook. To make this more clear, packaging has been moved into the new rail. You can manage dependencies directly.
 
 <Video
-  src="https://img.runt.run/2026/06/2.6-packaging.mp4"
-  poster="https://img.runt.run/2026/06/2.6-packaging.png"
+  src="https://img.runt.run/2026/06/2.6-packaging-v2.mp4"
+  poster="https://img.runt.run/2026/06/2.6-packaging-v2.png"
   caption="Adding a package from the rail, no notebook cell required"
 />
 
@@ -88,8 +88,8 @@ After landing the rail work, it was clear there was opportunity to create cleare
 ### Changing cell type
 
 <Video
-  src="https://img.runt.run/2026/06/2.6-change-cell-type.mp4"
-  poster="https://img.runt.run/2026/06/2.6-change-cell-type.png"
+  src="https://img.runt.run/2026/06/2.6-change-cell-type-v2.mp4"
+  poster="https://img.runt.run/2026/06/2.6-change-cell-type-v2.png"
   caption="Switching a cell between code and Markdown in place"
 />
 

--- a/content/changelog/2.6.mdx
+++ b/content/changelog/2.6.mdx
@@ -1,0 +1,213 @@
+---
+version: "2.6"
+date: "2026-06-10T00:00:00Z"
+coversVersions:
+  - "2.6.0"
+dateLabel: "Draft - June 10, 2026"
+title: "Hosted Notebooks, Workstations, and One Notebook Shell"
+summary: "The nteract 2.6 draft brings hosted notebooks closer to the desktop app: shared NotebookView surfaces, owner-run cloud execution, workstation compute, faster hosted outputs, and cleaner MCP resources."
+highlights:
+  - "Hosted notebooks can be shared, edited, and executed through owner-controlled runtime peers"
+  - "Desktop and cloud notebooks now converge on the same NotebookView shell, rail, capabilities, and actor model"
+  - "Publishing, widgets, output frames, Sift, and MCP resources got faster and harder to break"
+tags:
+  - "cloud"
+  - "workstations"
+  - "notebook"
+  - "mcp"
+published: false
+# githubReleaseUrl: "https://github.com/nteract/nteract/releases/tag/v2.6.0-stable.TODO"
+# heroImage: "https://img.runt.run/TODO/2.6-hero.png"
+# heroVideo: "https://img.runt.run/TODO/2.6-demo.mp4"
+---
+
+{/* 
+Release prep range, generated from /Users/kylekelley/code/src/github.com/nteract/nteract on 2026-06-10:
+
+Base: v2.5.1-stable.202605261941
+Base commit: 4867b005ac89d1ce28775c27a33f379da0d0f50e
+Head: origin/main
+Head commit: f6fba37ee12c414937859760b7fb59b2a4db7469
+Range: 4867b005ac89d1ce28775c27a33f379da0d0f50e..f6fba37ee12c414937859760b7fb59b2a4db7469
+First-parent commits at draft time: 441
+All commits at draft time: 666
+
+Before publishing 2.6, refresh the clone, replace the head commit with the final stable tag commit, regenerate the technical changelog, and update coversVersions/githubReleaseUrl/media.
+*/}
+
+2.6 is the release where the browser notebook stops feeling like a read-only postcard from the desktop app.
+
+This one is about making the same notebook surface show up in more places: local files, hosted rooms, shared links, runtime peers, workstation compute, and the agents that want to read or drive the notebook without inventing a second copy of it.
+
+I've wanted nteract cloud notebooks to feel less like "publish a snapshot" and more like "keep working in the same room." This release is the big step in that direction.
+
+## Hosted notebooks you can work in
+
+{/* TODO: add a short video showing a hosted notebook moving between viewer/editor modes, sharing controls, and live output updates. */}
+
+Hosted notebooks now have real room mechanics behind them. Owners can share notebooks, grant edit access, accept authenticated viewers, and keep browser sessions attached without turning every link into a one-off artifact.
+
+The cloud app learned about app sessions, owner-gated sharing controls, edit access requests, invite storage, friendlier presence labels, and hosted widget state that survives more of the weird browser edges. The point is boring in the best way: a hosted notebook should feel like a notebook you can keep using.
+
+## Run it from the cloud, keep the runtime yours
+
+{/* TODO: add a demo clip of starting workstation compute from the hosted toolbar. */}
+
+2.6 starts connecting hosted notebooks to real compute instead of pretending the viewer is the runtime.
+
+Runtime peers can attach to hosted rooms, accept execution intent, reconnect, re-auth, and publish their state back to the room. Workstations show up in the document rail and can be started from the hosted toolbar. There is a one-liner workstation install path in the current range, plus Anaconda API key support for the hosted side of the flow.
+
+This is the shape I want for cloud notebooks: the browser owns the collaboration and sharing surface, but the runtime stays explicit. You can see when compute is offline, when a peer is attached, and when a room is waiting on a runtime instead of guessing.
+
+## One NotebookView
+
+The desktop app and hosted cloud used to look related, but too much of the notebook chrome was duplicated. 2.6 cuts that down.
+
+The notebook view now shares more of its shell: the rail, capability model, headers, host notices, package summaries, search, environment panels, hidden-cell affordances, output focus, and execution language. That sounds internal, but it changes how the app feels. The cloud notebook and the desktop notebook are now arguing less about what a notebook is.
+
+You can see it in smaller things too: read-only markdown still navigates, editor controls gate themselves on host capabilities, execution status takes up less visual noise, and the left rail finally has enough structure to carry outline, packages, runtime, workstation, and search surfaces without becoming a junk drawer.
+
+## Markdown grew up
+
+Markdown is no longer just a React-side preview bolted to cells.
+
+This range moves markdown through the Rust/WASM markdown engine, adds richer document typography, fixes bare TeX environments, restores double-click editing, keeps document frames selectable, and uses markdown engine anchors for notebook outlines.
+
+That matters for hosted notebooks because markdown is the bridge between "notebook as code scratchpad" and "notebook as report." If the cloud view is going to be a real shared document, markdown has to be stable, navigable, and pleasant to read.
+
+## Outputs and widgets got more durable
+
+2.5 made outputs more explorable. 2.6 keeps pushing on the part where outputs must survive being published, framed, shared, cached, replayed, and read by tools.
+
+Widgets now save more live metadata. Progress widgets hydrate correctly in hosted views. Sift picked up image thumbnails and image navigation. Engaged Sift frames behave better with scroll boundaries. Output frames respect host frame domains, hosted viewers preload the sidecars they need, and blob metadata is harder to corrupt when the same output shows up twice.
+
+There is also a lot of unglamorous repair here: nested Arrow blobs, widget comm blobs, published output refs, first-paint theme seeding, direct output document transforms, and cached renderer assets. That is the work that makes a notebook output feel boringly present when it leaves your machine.
+
+## Hosted publishing is getting faster
+
+{/* TODO: add a before/after clip or timing capture for hosted output hydration. */}
+
+The viewer path got a serious round of performance work.
+
+Hosted notebooks now defer and stage more of the expensive output work: lazy output frame mounting, progressive output hydration, runtime WASM preloads, Sift WASM preloads, sidecar renderer assets, hosted output blob caching, viewer CSS splitting, and incremental live runtime projections.
+
+The user-facing version is simple: shared notebooks should load the notebook first, then get richer as the expensive pieces arrive. No one should wait for every widget, frame, stylesheet, and blob before reading the first cell.
+
+## MCP reads the notebook, not a shadow notebook
+
+MCP and agent surfaces are quieter and more notebook-native in 2.6.
+
+Cell reads prefer resources. Client display names are canonicalized. Generated icons are advertised. Proxy recovery messages are more install-aware. The notebook tool bridge is exposed from `runt`, and the hosted/browser runtime work gives agents a clearer route into the same notebook state a human sees.
+
+That is the part I care about most: tools should not need a parallel notebook model. They should read cells, outputs, identities, and runtime state from the same documents the app is already using.
+
+## Under the floorboards
+
+There is a lot of floorboard work in this range.
+
+Runtime state documents now carry identity. Widget comm state is split into `CommsDoc`. Autosave is more careful about stale rooms and empty-room overwrites. Fresh notebook seeding is daemon-owned. Connection status is observable. Local-first persistence gets a `notebookDocChanged$` signal. Runtimed has a test kernel and a clearer kernel dispatch enum. Sync peer egress lanes are split and classified.
+
+That is not a flashy list, but it is the kind of foundation this app needs before the same notebook can move between local editing, hosted viewing, shared execution, and agent tooling without losing the plot.
+
+## Things to finish before publishing
+
+- Replace the draft date with the final release date.
+- Replace `coversVersions` with the actual 2.6 stable and patch versions.
+- Add the final `githubReleaseUrl`.
+- Add the 2.6 hero image and any demo videos.
+- Refresh the commit range comment against the final stable tag.
+- Regenerate or paste the final technical changelog.
+- Trim any sections that are too implementation-heavy after the final release shape is clear.
+
+## Working technical changelog
+
+<details>
+<summary>Current draft range summary</summary>
+
+This section is a prep scaffold, not the final generated changelog.
+
+Current source range:
+
+```text
+4867b005ac89d1ce28775c27a33f379da0d0f50e..f6fba37ee12c414937859760b7fb59b2a4db7469
+```
+
+The range currently contains 441 first-parent commits and 666 total commits since `v2.5.1-stable.202605261941`.
+
+### Hosted notebooks and sharing
+
+- add hosted sharing controls ([cbe800f](https://github.com/nteract/nteract/commit/cbe800f4))
+- add hosted edit access requests ([67d0fcd](https://github.com/nteract/nteract/commit/67d0fcda))
+- grant editors full cell editing in hosted rooms ([956cce9](https://github.com/nteract/nteract/commit/956cce97))
+- render hosted notebooks through `NotebookView` ([2723268](https://github.com/nteract/nteract/commit/27232684))
+- bootstrap notebook home with app sessions ([5162237](https://github.com/nteract/nteract/commit/51622379))
+- polish notebook home and workstation panel ([5cb944c](https://github.com/nteract/nteract/commit/5cb944c1))
+- gate sharing controls to owners ([790b759](https://github.com/nteract/nteract/commit/790b7591))
+
+### Runtime peers and workstations
+
+- add `runt publish` helper ([39c7acc](https://github.com/nteract/nteract/commit/39c7acc5))
+- accept Anaconda API keys ([61ccd18](https://github.com/nteract/nteract/commit/61ccd186))
+- add preview OIDC login ([4444f9f](https://github.com/nteract/nteract/commit/4444f9fc))
+- add cloud runtime lifecycle ([809cf01](https://github.com/nteract/nteract/commit/809cf01e))
+- add transport-agnostic `runtime_agent` and cloud WebSocket transport ([9c87bd0](https://github.com/nteract/nteract/commit/9c87bd01))
+- add daemon workstation endpoint ([8660705](https://github.com/nteract/nteract/commit/86607050))
+- register hosted workstations ([b3b10f5](https://github.com/nteract/nteract/commit/b3b10f59))
+- project workstation launch contract ([c100d41](https://github.com/nteract/nteract/commit/c100d414))
+- start workstation compute from the toolbar ([ddbaa4e](https://github.com/nteract/nteract/commit/ddbaa4e7))
+
+### Notebook shell convergence
+
+- add shared notebook rail shell ([5b365b8](https://github.com/nteract/nteract/commit/5b365b8b))
+- add contextual outline tree ([db4b61a](https://github.com/nteract/nteract/commit/db4b61ac))
+- add left rail panels ([f07b528](https://github.com/nteract/nteract/commit/f07b5286))
+- add capability-scoped document header ([fdf13aa](https://github.com/nteract/nteract/commit/fdf13aae))
+- drive `NotebookView` from shell capabilities ([8af8135](https://github.com/nteract/nteract/commit/8af81352))
+- refine hidden and output surfaces ([5b5fda8](https://github.com/nteract/nteract/commit/5b5fda8f))
+- share runtime command projection ([90cdb05](https://github.com/nteract/nteract/commit/90cdb057))
+- add connection status and local-first persistence signals ([50187ab](https://github.com/nteract/nteract/commit/50187ab2))
+
+### Markdown, outputs, and widgets
+
+- add traceback frame navigation ([b96f758](https://github.com/nteract/nteract/commit/b96f7584))
+- add Sift image thumbnail viewer ([f8a308e](https://github.com/nteract/nteract/commit/f8a308ed))
+- add Sift image viewer navigation ([3fd5852](https://github.com/nteract/nteract/commit/3fd5852f))
+- project markdown through Rust WASM ([5d4682e](https://github.com/nteract/nteract/commit/5d4682e1))
+- refine document typography ([e113ccb](https://github.com/nteract/nteract/commit/e113ccb2))
+- keep document frames selectable ([449315f](https://github.com/nteract/nteract/commit/449315fd))
+- split widget comm state into `CommsDoc` ([13a5fe2](https://github.com/nteract/nteract/commit/13a5fe23))
+- project `CommsDoc` widget state to Python ([54339c1](https://github.com/nteract/nteract/commit/54339c12))
+- save live widget state metadata ([644933e](https://github.com/nteract/nteract/commit/644933e8))
+
+### Performance and hosted viewer loading
+
+- preload Sift WASM for live views ([cf8172a](https://github.com/nteract/nteract/commit/cf8172a3))
+- hydrate hosted outputs progressively ([d16326e](https://github.com/nteract/nteract/commit/d16326e1))
+- load renderer from sidecar assets ([98663df](https://github.com/nteract/nteract/commit/98663df4))
+- defer supplemental viewer CSS ([a6e94b2](https://github.com/nteract/nteract/commit/a6e94b2e))
+- stage async output resolution ([8f32259](https://github.com/nteract/nteract/commit/8f322592))
+- lazy mount output frames ([91f3977](https://github.com/nteract/nteract/commit/91f3977d))
+- cache hosted output blobs ([5499951](https://github.com/nteract/nteract/commit/5499951d))
+- project live runtime updates incrementally ([679c6ae](https://github.com/nteract/nteract/commit/679c6ae2))
+- coalesce concurrent text-blob fetches ([f908f43](https://github.com/nteract/nteract/commit/f908f431))
+
+### MCP, agents, and tooling
+
+- canonicalize MCP client display names ([c9f24ae](https://github.com/nteract/nteract/commit/c9f24ae3))
+- advertise generated MCP icons ([b6b6db7](https://github.com/nteract/nteract/commit/b6b6db78))
+- prefer resources for cell reads ([689034e](https://github.com/nteract/nteract/commit/689034e9))
+- expose notebook tool bridge ([497a3fa](https://github.com/nteract/nteract/commit/497a3fa7))
+- make proxy recovery messages install-aware ([c84481d](https://github.com/nteract/nteract/commit/c84481d6))
+- make Codex notebook MCP installs distinct ([1823167](https://github.com/nteract/nteract/commit/18231676))
+
+### Safety and foundations
+
+- add runtime state document identity ([e385d80](https://github.com/nteract/nteract/commit/e385d806))
+- seed runtime state document identity in rooms ([2cdcd22](https://github.com/nteract/nteract/commit/2cdcd225))
+- gate hosted runtime state writes ([3573305](https://github.com/nteract/nteract/commit/35733050))
+- do not autosave an empty room over a non-empty notebook file ([7c2a255](https://github.com/nteract/nteract/commit/7c2a255b))
+- make fresh notebook seeding daemon-owned ([2d1da4a](https://github.com/nteract/nteract/commit/2d1da4a3))
+- refuse stale autosaves and write `.ipynb` atomically ([7c36d0f](https://github.com/nteract/nteract/commit/7c36d0fc))
+- add `TestKernel` and kernel dispatch enum ([dc77f16](https://github.com/nteract/nteract/commit/dc77f16b))
+
+</details>

--- a/content/changelog/2.6.mdx
+++ b/content/changelog/2.6.mdx
@@ -80,8 +80,8 @@ After landing the rail work, it was clear there was opportunity to create cleare
 ### Motion on execution
 
 <Video
-  src="https://img.runt.run/2026/06/2.6-cell-motion.mp4"
-  poster="https://img.runt.run/2026/06/2.6-cell-motion.png"
+  src="https://img.runt.run/2026/06/2.6-cell-motion-v2.mp4"
+  poster="https://img.runt.run/2026/06/2.6-cell-motion-v2.png"
   caption="Execution, reveal, and focus transitions in the redesigned shell"
 />
 

--- a/content/changelog/2.6.mdx
+++ b/content/changelog/2.6.mdx
@@ -27,8 +27,8 @@ This release makes me very proud. I redesigned the cell chrome, created a markdo
 ## Find your place in long notebooks
 
 <Video
-  src="https://img.runt.run/2026/06/2.6-outline.mp4"
-  poster="https://img.runt.run/2026/06/2.6-outline.png"
+  src="https://img.runt.run/2026/06/2.6-outline-v2.mp4"
+  poster="https://img.runt.run/2026/06/2.6-outline-v2.png"
   caption="The outline rail jumping between sections of a long notebook"
 />
 

--- a/content/changelog/2.6.mdx
+++ b/content/changelog/2.6.mdx
@@ -119,7 +119,6 @@ nteract can tidy code on its way in: `ruff` for Python, `deno fmt` for the rest.
 
 ## Things to finish before publishing
 
-- Confirm the commenting UI is gated off for the 2.6 release channel (it launches publicly in 2.7).
 - Replace the draft date with the final release date.
 - Replace `coversVersions` with the actual 2.6 stable and patch versions.
 - Add the final `githubReleaseUrl`.

--- a/content/changelog/2.6.mdx
+++ b/content/changelog/2.6.mdx
@@ -36,6 +36,8 @@ Range: 4867b005ac89d1ce28775c27a33f379da0d0f50e..f6fba37ee12c414937859760b7fb59b
 First-parent commits at draft time: 441
 All commits at draft time: 666
 
+Updated 2026-06-21: the two 2.6 add-ons merged after this snapshot (cell-type switching #3803 = 191aa48, auto-format opt-out #3802 = 1f3d922), so main has advanced past f6fba37. The counts above are the 2026-06-10 snapshot.
+
 Before publishing 2.6, refresh the clone, replace the head commit with the final stable tag commit, regenerate the technical changelog, and update coversVersions/githubReleaseUrl/media.
 */}
 
@@ -109,13 +111,14 @@ The switch is an edit on the cell itself, so its place in the notebook and anyth
 
 ## Formatting on your terms
 
+{/* TODO: capture the settings toggle for automatic formatting. */}
+
 nteract can tidy code on its way in: `ruff` for Python, `deno fmt` for the rest. Some people love it. Some people want their code left exactly as written.
 
 2.6 adds a setting to turn automatic reformatting off. When it is off, the notebook stops rewriting code you did not ask it to touch. Auto-format stays the default for the people who like it, but it is no longer something the editor insists on. This closes a long-standing request ([#3795](https://github.com/nteract/nteract/issues/3795)).
 
 ## Things to finish before publishing
 
-- Land the two user-feedback add-ons (cell type switching, auto-format opt-out) and add their commits to the technical changelog.
 - Confirm the commenting UI is gated off for the 2.6 release channel (it launches publicly in 2.7).
 - Replace the draft date with the final release date.
 - Replace `coversVersions` with the actual 2.6 stable and patch versions.
@@ -178,5 +181,10 @@ The range currently contains 441 first-parent commits and 666 total commits sinc
 - soften hidden cell reveal rows ([5477469](https://github.com/nteract/nteract/commit/54774693))
 - quiet completed cell status ([335f0ab](https://github.com/nteract/nteract/commit/335f0ab9))
 - keep hidden cell keyboard navigation moving ([f2555da](https://github.com/nteract/nteract/commit/f2555da2))
+
+### Cell editing and formatting
+
+- switch cell type between code and Markdown from the menus ([191aa48](https://github.com/nteract/nteract/commit/191aa484c))
+- add a setting to opt out of automatic ruff / deno fmt ([1f3d922](https://github.com/nteract/nteract/commit/1f3d92222))
 
 </details>

--- a/content/changelog/2.6.mdx
+++ b/content/changelog/2.6.mdx
@@ -3,6 +3,7 @@ version: "2.6"
 date: "2026-06-25T00:00:00Z"
 coversVersions:
   - "2.6.0"
+  - "2.6.1"
 dateLabel: "June 25, 2026"
 title: "Outlines of the Railway"
 summary: "nteract 2.6 polishes design with a left rail, outlines, packaging selection, and improved markdown + TeX rendering."
@@ -19,6 +20,7 @@ published: true
 githubReleaseUrl: "https://github.com/nteract/nteract/releases/tag/v2.6.0-stable.202606251403"
 heroVideo: "https://img.runt.run/2026/06/2.6-outline-editing-cursor.mp4"
 heroVideoPoster: "https://img.runt.run/2026/06/2.6-hero-poster-cursor.png"
+heroImage: "https://img.runt.run/2026/06/2.6-og.png"
 ---
 
 This release makes me very proud. I redesigned the cell chrome, created a markdown pipeline, and brought back everyone's favorite ToC. The focus in 2.5 was around outputs: navigable tracebacks, explorable DataFrames, and keeping secrets out of the outputs. In the 2.6 release we're turning back to document operations. Long notebooks get more structure with a dedicated table of contents/outline, tooling like package selection moves into a dedicated rail with room for more, and additional editing controls.

--- a/content/changelog/2.6.mdx
+++ b/content/changelog/2.6.mdx
@@ -44,21 +44,15 @@ Can we all agree that this is not how we should install dependencies in a notebo
 ! [ -e /content ] && pip install -Uqq fastbook
 ```
 
-Not everyone realized you could click this button to install deps into an nteract notebook:
-
-{/* Python button screenshot */}
-
-Or that a notebook in a project space would just use that project's env. 
-
-{/* Project info screenshot */}
-
-Packaging moves into the new rail, so you can manage dependencies directly.
+Not everyone realized you could click <RuntimeBadge runtime="python" manager="uv" /> to install deps into an nteract notebook. To make this more clear, packaging has been moved into the new rail. You can manage dependencies directly.
 
 <Video
   src="https://img.runt.run/2026/06/2.6-packaging.mp4"
   poster="https://img.runt.run/2026/06/2.6-packaging.png"
   caption="Adding a package from the rail, no notebook cell required"
 />
+
+The big key with nteract though is to lean into your project's environment. Don't manage within the notebook itself, use the same dependencies you'll be using in production with your pyproject.toml, environment.yaml, or pixi.toml.
 
 Hopefully now you'll be able to know the environment you have without needing a cell-shaped interruption in your notebook.
 

--- a/content/changelog/2.6.mdx
+++ b/content/changelog/2.6.mdx
@@ -63,6 +63,12 @@ Markdown got more serious in 2.6.
 
 Bare TeX environments now project as math instead of plain text, completing compatibility with Jupyter notebooks. Write notebooks as they were intended, as a computational narrative that allows you to collaborate with others. Not just a pile of code cells.
 
+<LightboxImage
+  src="https://img.runt.run/2026/06/2.6-markdown-tex.png"
+  alt="A notebook rendering bare TeX as math: a list with inline math, equation-numbered align blocks, and display equations"
+  className="my-10 w-full"
+/>
+
 As part of this release, there's a new Rust/WASM markdown engine. Users don't have to know about it, but it creates steadier parsing, better outline anchors, and very fast rendering. I'm hoping the document experience can go further from here.
 
 ## Grand gestures of simplicity

--- a/content/changelog/2.6.mdx
+++ b/content/changelog/2.6.mdx
@@ -24,7 +24,11 @@ This release makes me very proud. I redesigned the cell chrome, created a markdo
 
 ## Find your place in long notebooks
 
-{/* Show a nifty outline GIF here */}
+<Video
+  src="https://img.runt.run/2026/06/2.6-outline.mp4"
+  poster="https://img.runt.run/2026/06/2.6-outline.png"
+  caption="The outline rail jumping between sections of a long notebook"
+/>
 
 Click the outline view in the rail to hop between markdown segments and image outputs within your notebooks.
 
@@ -50,7 +54,11 @@ Or that a notebook in a project space would just use that project's env.
 
 Packaging moves into the new rail, so you can manage dependencies directly.
 
-{/* GIF of adding packages */}
+<Video
+  src="https://img.runt.run/2026/06/2.6-packaging.mp4"
+  poster="https://img.runt.run/2026/06/2.6-packaging.png"
+  caption="Adding a package from the rail, no notebook cell required"
+/>
 
 Hopefully now you'll be able to know the environment you have without needing a cell-shaped interruption in your notebook.
 
@@ -73,7 +81,11 @@ After landing the rail work, it was clear there was opportunity to create cleare
 
 ### Motion on execution
 
-{/* Animation of the new execution, reveal, focus, and transitions */}
+<Video
+  src="https://img.runt.run/2026/06/2.6-cell-motion.mp4"
+  poster="https://img.runt.run/2026/06/2.6-cell-motion.png"
+  caption="Execution, reveal, and focus transitions in the redesigned shell"
+/>
 
 ### Changing cell type
 

--- a/content/changelog/2.6.mdx
+++ b/content/changelog/2.6.mdx
@@ -71,7 +71,11 @@ After landing the rail work, it was clear there was opportunity to create cleare
 
 ### Hidden cells use clearer language
 
-{/* Hidden cell screenshots */}
+<LightboxImage
+  src="https://img.runt.run/2026/06/2.6-hidden-cells.png"
+  alt="Hidden cells with clearer reveal language"
+  className="my-10 w-full border border-[var(--rule)]"
+/>
 
 ### Motion on execution
 
@@ -83,7 +87,11 @@ After landing the rail work, it was clear there was opportunity to create cleare
 
 ### Changing cell type
 
-{/* GIF of changing cell type */}
+<Video
+  src="https://img.runt.run/2026/06/2.6-change-cell-type.mp4"
+  poster="https://img.runt.run/2026/06/2.6-change-cell-type.png"
+  caption="Switching a cell between code and Markdown in place"
+/>
 
 Right click a cell or use the menu to change its type in place.
 

--- a/content/changelog/2.6.mdx
+++ b/content/changelog/2.6.mdx
@@ -9,9 +9,8 @@ summary: "nteract 2.6 polishes design with a left rail, outlines, packaging sele
 highlights:
   - "Navigate long notebooks from a left-rail outline"
   - "Manage packages from the rail without turning dependencies into notebook cells"
-  - "Switch cells between code and Markdown from the context and main menus"
+  - "Switch cells between code and markdown from the context and main menus"
   - "Disable automatic code formatting when exact source layout matters"
-  - "Keep widget state and rich output renders steadier across sessions"
 tags:
   - "design"
   - "rail"
@@ -20,73 +19,77 @@ published: true
 githubReleaseUrl: "https://github.com/nteract/nteract/releases/tag/v2.6.0-stable.202606251403"
 ---
 
-2.6 is a notebook ergonomics release.
+This release makes me very proud. I redesigned the cell chrome, created a markdown pipeline, and brought back everyone's favorite ToC. The focus in 2.5 was around outputs: navigable tracebacks, explorable DataFrames, and keeping secrets out of the outputs. In the 2.6 release we're turning back to document operations. Long notebooks get more structure with a dedicated table of contents/outline, tooling like package selection moves into a dedicated rail with room for more, and additional editing controls.
 
-2.5 made outputs richer: navigable tracebacks, explorable DataFrames, and secrets that stay out of notebook output. 2.6 turns back to the day-to-day notebook surface. It gives long notebooks more structure, moves supporting tools into the rail, makes widget state less temporary, and adds the small editing controls people asked for after living in the app.
-
-The theme is simple: the notebook should stay centered, and the workspace around it should help without taking over.
 
 ## Find your place in long notebooks
 
-Long notebooks now get an outline in the left rail.
+{/* Show a nifty outline GIF here */}
 
-Headings become landmarks. You can skim the document structure, jump between sections, and keep the cell body focused on the work itself. The outline also keeps improving as Markdown rendering moves through the shared Rust/WASM path, so anchors and headings are not a separate, fragile interpretation of the document.
+Click the outline view in the rail to hop between markdown segments and image outputs within your notebooks.
 
-This is the clearest new shape in 2.6: the notebook body is for cells, and the rail is for the surrounding instruments that help you move through them.
+{/* Show another outline that changes as you edit markdown headings */}
+
+The outline shows your heading hierarchy and updates live as you edit.
 
 ## Packages belong beside the notebook
 
-Managing packages is part of notebook work. It is also not the notebook itself.
+Can we all agree that this is not how we should install dependencies in a notebook?
 
-2.6 moves package management into the same rail model as the outline. Package state stays attached to the notebook, but dependency management no longer needs to compete with prose, code, and output for space in the main document. You can see what the notebook depends on, adjust it, and get back to the cells faster.
+```bash
+! [ -e /content ] && pip install -Uqq fastbook
+```
 
-This is one of those changes that matters most after repetition: the environment is still visible, but it stops feeling like another cell-shaped interruption.
+Not everyone realized you could click this button to install deps into an nteract notebook:
 
-## Widgets remember more
+{/* Python button screenshot */}
 
-Widget state is the sleeper feature in this release.
+Or that a notebook in a project space would just use that project's env. 
 
-Once a widget becomes part of how you explore a notebook, replaying code and hoping the UI lands in the same place is not enough. Sliders, controls, progress views, and comm-backed state need to survive more of a notebook's real life: opening, saving, reloading, and reconnecting.
+{/* Project info screenshot */}
 
-2.6 saves live widget state metadata more reliably and moves comm state into a clearer document path. The user-facing version is simple: widgets should feel less disposable.
+Packaging moves into the new rail, so you can manage dependencies directly.
+
+{/* GIF of adding packages */}
+
+Hopefully now you'll be able to know the environment you have without needing a cell-shaped interruption in your notebook.
+
 
 ## Markdown reads more like a document
 
 Markdown got more serious in 2.6.
 
-Bare TeX environments now project as math instead of plain text. If you write a notebook as a document, not just as a pile of code cells, equations should read as equations.
+Bare TeX environments now project as math instead of plain text, completing compatibility with Jupyter notebooks. Write notebooks as they were intended, as a computational narrative that allows you to collaborate with others. Not just a pile of code cells.
 
-The Markdown path is also moving through the Rust/WASM markdown engine. Users do not need to care about the engine by name, but they should care about what it enables: steadier parsing, shared behavior, better outline anchors, and Markdown cells that can carry more of the document experience without special cases.
+As part of this release, there's a new Rust/WASM markdown engine. Users don't have to know about it, but it creates steadier parsing, better outline anchors, and very fast rendering. I'm hoping the document experience can go further from here.
 
-## The notebook shell settles down
+## Grand gestures of simplicity
 
-There is a lot of design work in 2.6, and it should not disappear under the word "polish."
+After landing the rail work, it was clear there was opportunity to create clearer affordances for what you can do, what state a cell is in, and where the next action lives. Here's a tour of the small things we polished:
 
-The notebook shell has clearer affordances for what you can do, what state a cell is in, and where the next action lives. Hidden cells use clearer language. Completed cells get quieter. Structure edits gate themselves on host support. The rail can carry more responsibility, so the notebook body can stay focused on cells and output.
+### Hidden cells use clearer language
 
-There is new motion here too: not animation for decoration, but animation that helps the notebook explain itself. Execution, reveal, focus, and shell transitions feel less abrupt when the interface has a little choreography.
+{/* Hidden cell screenshots */}
 
-The result is an app that asks you to re-orient less often.
+### Motion on execution
 
-## Change the cell you already have
+{/* Animation of the new execution, reveal, focus, and transitions */}
 
-A cell should not be stuck as the type you first made it.
+### Changing cell type
 
-2.6 makes switching a cell between code and Markdown a first-class move. Right-click a cell, or use the main menu, and change its type in place. That covers the everyday notebook loop: write a thought in Markdown, turn a scratch cell back into code, or correct the type without deleting and recreating anything.
+{/* GIF of changing cell type */}
 
-The switch is an edit on the cell itself, so its place in the notebook and anything anchored to it come along for the ride. This came straight from user feedback, and it is the kind of small thing you stop noticing precisely because it stopped getting in your way.
+Right click a cell or use the menu to change its type in place.
 
-## Formatting becomes a choice
+## Feature Flag Preview: Comments
 
-nteract can tidy code on its way through the notebook: `ruff` for Python and `deno fmt` for the rest. Some people love that. Some people want their source left exactly as written.
+This release has a still-in-development feature of commenting. If you want to try it out, turn on **Enable Comments UI** in Settings under Feature Flags. Select any code, rendered markdown, or outputs then leave a note. Leave replies in the discussion rail. This feature makes more sense when collaborating with users, which is why it's gated until hosted documents are available. _However_, you can start letting agents comment on your documents too.
 
-2.6 adds **Disable automatic formatting** in Settings. Auto-formatting stays on by default for the people who want it, but the editor no longer insists on rewriting code when exact layout matters. This closes a long-standing request ([#3795](https://github.com/nteract/nteract/issues/3795)).
+## What's next
 
-## A quiet comments preview
+Under the hood we've laid the foundations to extend the local realtime model to a real multiuser collaborative experience on the web, complete with attribution and identity backed by any OIDC provider.
 
-There is one more thing in 2.6, and it is intentionally quiet. Turn on **Enable Comments UI** in Settings, under Feature Flags, and you can try the new notebook commenting surface: select code or rendered Markdown, leave a note, and reply in the discussion rail.
-
-The preview ships off by default. 2.6 gives early testers a way to try the surface before the public 2.7 commenting release, where anchoring, authorship, and the full discussion model get their own introduction.
+More on this soon. Reach out on [~~Twitter~~ X](https://x.com/KyleRayKelley), [LinkedIn](https://www.linkedin.com/in/kyleraykelley/), or [post a GitHub issue](https://github.com/nteract/nteract/issues/new).
 
 ## Technical changelog
 

--- a/content/changelog/2.6.mdx
+++ b/content/changelog/2.6.mdx
@@ -1,17 +1,17 @@
 ---
 version: "2.6"
-date: "2026-06-10T00:00:00Z"
+date: "2026-06-23T00:00:00Z"
 coversVersions:
   - "2.6.0"
-dateLabel: "Draft - June 10, 2026"
-title: "Table of Contents, Notebook Design, Widget State"
-summary: "The nteract 2.6 draft focuses the notebook workspace: a table of contents for long notebooks, package management in the rail, a more polished notebook shell, widget state that survives more of your work, Markdown including bare TeX, plus two from user feedback: switching a cell between code and Markdown from the menus, and an opt-out for automatic code formatting."
+dateLabel: "Draft - June 23, 2026"
+title: "Outline, Editing Controls, and Widget State"
+summary: "nteract 2.6 tightens the desktop notebook: a left-rail outline, package panels that stay out of the notebook body, stronger widget state restoration, better Markdown and TeX rendering, first-class code/Markdown cell conversion, and a setting to disable automatic formatting."
 highlights:
-  - "Switch a cell between code and Markdown from the context and main menus"
-  - "Turn off automatic code reformatting when you want your code left as written"
-  - "Long notebooks now get an outline / table of contents"
-  - "The notebook shell has new affordances, cleaner cell states, and more intentional motion"
-  - "Widget state is saved and restored more reliably across notebook sessions"
+  - "Navigate long notebooks from a left-rail outline"
+  - "Manage packages from the rail without turning dependencies into notebook cells"
+  - "Switch cells between code and Markdown from the context and main menus"
+  - "Disable automatic code formatting when exact source layout matters"
+  - "Keep widget state and rich output renders steadier across sessions"
 tags:
   - "notebook"
   - "design"
@@ -25,49 +25,51 @@ published: false
 # heroVideo: "https://img.runt.run/TODO/2.6-demo.mp4"
 ---
 
-{/* 
-Release prep range, generated from /Users/kylekelley/code/src/github.com/nteract/nteract on 2026-06-10:
+{/*
+Release prep notes, refreshed from /home/ubuntu/projects/nteract on 2026-06-23.
 
 Base: v2.5.1-stable.202605261941
 Base commit: 4867b005ac89d1ce28775c27a33f379da0d0f50e
-Head: origin/main
-Head commit: f6fba37ee12c414937859760b7fb59b2a4db7469
-Range: 4867b005ac89d1ce28775c27a33f379da0d0f50e..f6fba37ee12c414937859760b7fb59b2a4db7469
-First-parent commits at draft time: 441
-All commits at draft time: 666
+Head: release/2.6.0
+Head commit: 3376f1e865a9d19d32507cb90718084b3a2fa1c3
+Range: 4867b005ac89d1ce28775c27a33f379da0d0f50e..3376f1e865a9d19d32507cb90718084b3a2fa1c3
+First-parent commits at draft time: 678
+All commits at draft time: 903
 
-Updated 2026-06-21: the two 2.6 add-ons merged after this snapshot (cell-type switching #3803 = 191aa48, auto-format opt-out #3802 = 1f3d922), so main has advanced past f6fba37. The counts above are the 2026-06-10 snapshot.
-
-Before publishing 2.6, refresh the clone, replace the head commit with the final stable tag commit, regenerate the technical changelog, and update coversVersions/githubReleaseUrl/media.
+Before publishing:
+- Replace the draft date with the final stable release date.
+- Replace coversVersions with the final stable and patch versions.
+- Add the final githubReleaseUrl.
+- Add the 2.6 hero image and any demo videos.
+- Refresh the range against the final stable tag if it differs from the release branch head.
+- Replace the draft technical changelog with the generated final changelog.
 */}
 
-2.6 is the release where the notebook gets more shape around the work you are already doing.
+2.6 is a notebook ergonomics release.
 
-2.5 made outputs feel richer: navigable tracebacks, explorable DataFrames, and secrets that stay out of notebook output. 2.6 is quieter, but it is the kind of quiet that matters after a few hours in the same notebook. Navigation moves closer. Packages stop competing with the page. Cell states get clearer. The shell has more intentional affordances and motion. Widgets remember more. Markdown behaves more like a document.
+2.5 made outputs richer: navigable tracebacks, explorable DataFrames, and secrets that stay out of notebook output. 2.6 turns back to the day-to-day notebook surface. It gives long notebooks more structure, moves supporting tools into the rail, makes widget state less temporary, and adds the small editing controls people asked for after living in the app.
 
-This is a notebook ergonomics release.
+The theme is simple: the notebook should stay centered, and the workspace around it should help without taking over.
 
-## Table of Contents
+## Find your place in long notebooks
 
 {/* TODO: add a screenshot or short clip of the left rail switching between outline and package panels. */}
 
 Long notebooks now get an outline in the left rail.
 
-That sounds small until every heading has become a landmark. Instead of scrolling by vibes, you can skim the document structure, jump between sections, and keep the notebook body focused on the cells themselves.
+Headings become landmarks. You can skim the document structure, jump between sections, and keep the cell body focused on the work itself. The outline also keeps improving as Markdown rendering moves through the shared Rust/WASM path, so anchors and headings are not a separate, fragile interpretation of the document.
 
-The rail also gives package management a better home. Package state belongs near the notebook, but it does not need to live in the notebook body. Moving package management into the rail makes the environment feel attached to the work without turning dependency management into another cell-shaped distraction.
+This is the clearest new shape in 2.6: the notebook body is for cells, and the rail is for the surrounding instruments that help you move through them.
 
-I like this direction because it makes nteract feel less like an editor with a notebook inside it and more like a notebook with the right surrounding instruments.
-
-## Package management moved out of the way
+## Packages belong beside the notebook
 
 {/* TODO: add a focused media capture of package management in the rail. */}
 
 Managing packages is part of notebook work. It is also not the notebook itself.
 
-The 2.6 rail work makes package panels and summaries feel like part of the workspace chrome instead of a one-off interruption. You can keep track of the environment, see what the notebook depends on, and get back to the cells faster.
+2.6 moves package management into the same rail model as the outline. Package state stays attached to the notebook, but dependency management no longer needs to compete with prose, code, and output for space in the main document. You can see what the notebook depends on, adjust it, and get back to the cells faster.
 
-This is the same philosophy behind the rest of the rail: outline, packages, runtime, search, and other notebook-adjacent tools should be available without taking over the notebook.
+This is one of those changes that matters most after repetition: the environment is still visible, but it stops feeling like another cell-shaped interruption.
 
 ## Widgets remember more
 
@@ -75,67 +77,57 @@ This is the same philosophy behind the rest of the rail: outline, packages, runt
 
 Widget state is the sleeper feature in this release.
 
-Some of the pressure for this came from work on hosted notebooks, but the feature matters on the desktop too. Once a widget becomes part of how you explore a notebook, it is not enough to replay the code and hope the UI lands in the same place. Sliders, progress, controls, and comm-backed state need to survive more of the notebook's real life.
+Once a widget becomes part of how you explore a notebook, replaying code and hoping the UI lands in the same place is not enough. Sliders, controls, progress views, and comm-backed state need to survive more of a notebook's real life: opening, saving, reloading, and reconnecting.
 
-2.6 saves live widget state metadata more reliably and moves widget comm state into a clearer document path. The user-facing version is simple: widgets should feel less temporary.
+2.6 saves live widget state metadata more reliably and moves comm state into a clearer document path. The user-facing version is simple: widgets should feel less disposable.
 
-## Bare TeX works
+## Markdown reads more like a document
 
 Markdown got more serious in 2.6.
 
-Bare TeX environments now project as math instead of sitting there like slightly suspicious plain text. If you write a notebook as a document, not just as a pile of code cells, that matters. Equations should read as equations.
+Bare TeX environments now project as math instead of plain text. If you write a notebook as a document, not just as a pile of code cells, equations should read as equations.
 
-The Markdown path is also moving through the Rust/WASM markdown engine. Users probably do not need to care about the engine by name, but they should care about what it unlocks: steadier parsing, shared behavior, better anchors for outlines, and a Markdown cell that can carry more of the document experience without special cases.
+The Markdown path is also moving through the Rust/WASM markdown engine. Users do not need to care about the engine by name, but they should care about what it enables: steadier parsing, shared behavior, better outline anchors, and Markdown cells that can carry more of the document experience without special cases.
 
-## A better notebook shell
+## The notebook shell settles down
 
 {/* TODO: add a short clip that shows the new cell affordances and animations in motion. */}
 
-There is a lot of new design work in 2.6, and I do not want it to disappear under the word "polish."
+There is a lot of design work in 2.6, and it should not disappear under the word "polish."
 
-The notebook shell has better affordances for what you can do, what state a cell is in, and where the next action lives. Hidden cells have clearer language. Completed cells quiet down. Structure edits gate themselves on host support. The rail can carry more responsibility. The notebook body gets to stay the notebook body.
+The notebook shell has clearer affordances for what you can do, what state a cell is in, and where the next action lives. Hidden cells use clearer language. Completed cells get quieter. Structure edits gate themselves on host support. The rail can carry more responsibility, so the notebook body can stay focused on cells and output.
 
-There is new motion here too: not animation for decoration, but animation that helps the notebook explain itself. Execution, reveal, focus, and shell transitions can feel less abrupt when the interface has a little choreography.
+There is new motion here too: not animation for decoration, but animation that helps the notebook explain itself. Execution, reveal, focus, and shell transitions feel less abrupt when the interface has a little choreography.
 
-That may sound like vibes until you spend a day in the notebook. Then it becomes the difference between an app that constantly asks you to re-orient and an app that keeps you in the work.
+The result is an app that asks you to re-orient less often.
 
-## Switch a cell between code and Markdown
+## Change the cell you already have
 
 {/* TODO: capture the cell context menu showing the change-type entry. */}
 
 A cell should not be stuck as the type you first made it.
 
-2.6 makes switching a cell between code and Markdown a first-class move. Right-click a cell, or use the main menu, and change its type. Mostly that is the everyday loop of writing a notebook that is half prose and half computation: drop into Markdown to explain, back to code to compute, without deleting and recreating cells.
+2.6 makes switching a cell between code and Markdown a first-class move. Right-click a cell, or use the main menu, and change its type in place. That covers the everyday notebook loop: write a thought in Markdown, turn a scratch cell back into code, or correct the type without deleting and recreating anything.
 
-The switch is an edit on the cell itself, so its place in the notebook and anything anchored to it come along for the ride. This one came straight from user feedback, and it is the kind of small thing you stop noticing precisely because it stopped getting in your way.
+The switch is an edit on the cell itself, so its place in the notebook and anything anchored to it come along for the ride. This came straight from user feedback, and it is the kind of small thing you stop noticing precisely because it stopped getting in your way.
 
-## Formatting on your terms
+## Formatting becomes a choice
 
-{/* TODO: capture the settings toggle for automatic formatting. */}
+{/* TODO: capture the Disable automatic formatting setting. */}
 
-nteract can tidy code on its way in: `ruff` for Python, `deno fmt` for the rest. Some people love it. Some people want their code left exactly as written.
+nteract can tidy code on its way through the notebook: `ruff` for Python and `deno fmt` for the rest. Some people love that. Some people want their source left exactly as written.
 
-2.6 adds a setting to turn automatic reformatting off. When it is off, the notebook stops rewriting code you did not ask it to touch. Auto-format stays the default for the people who like it, but it is no longer something the editor insists on. This closes a long-standing request ([#3795](https://github.com/nteract/nteract/issues/3795)).
+2.6 adds **Disable automatic formatting** in Settings. Auto-formatting stays on by default for the people who want it, but the editor no longer insists on rewriting code when exact layout matters. This closes a long-standing request ([#3795](https://github.com/nteract/nteract/issues/3795)).
 
 ## A quiet comments preview
 
 {/* TODO: optional small capture of the Enable Comments UI flag, or leave it for the 2.7 splash. */}
 
-There is one more thing in 2.6, and it is on purpose that you have to go looking for it. Turn on **Enable Comments UI** in Settings, under Feature Flags, and you can comment on a notebook: select a bit of code or rendered Markdown, leave a note, and reply in a discussion rail.
+There is one more thing in 2.6, and it is intentionally quiet. Turn on **Enable Comments UI** in Settings, under Feature Flags, and you can try the new notebook commenting surface: select code or rendered Markdown, leave a note, and reply in the discussion rail.
 
-It ships off by default. 2.6 is the soft preview for people who want to kick the tires early. The real introduction, anchoring that survives edits, author identity for the people and agents in a notebook, and the whole discussion model, is the 2.7 release.
+The preview ships off by default. 2.6 gives early testers a way to try the surface before the public 2.7 commenting release, where anchoring, authorship, and the full discussion model get their own introduction.
 
-## Things to finish before publishing
-
-- Replace the draft date with the final release date.
-- Replace `coversVersions` with the actual 2.6 stable and patch versions.
-- Add the final `githubReleaseUrl`.
-- Add the 2.6 hero image and any demo videos.
-- Refresh the commit range comment against the final stable tag.
-- Regenerate or paste the final technical changelog.
-- Trim any sections that still read too implementation-heavy after the release shape is final.
-
-## Working technical changelog
+## Draft technical changelog
 
 <details>
 <summary>Current draft range summary</summary>
@@ -145,10 +137,10 @@ This section is a prep scaffold, not the final generated changelog.
 Current source range:
 
 ```text
-4867b005ac89d1ce28775c27a33f379da0d0f50e..f6fba37ee12c414937859760b7fb59b2a4db7469
+4867b005ac89d1ce28775c27a33f379da0d0f50e..3376f1e865a9d19d32507cb90718084b3a2fa1c3
 ```
 
-The range currently contains 441 first-parent commits and 666 total commits since `v2.5.1-stable.202605261941`.
+The range currently contains 678 first-parent commits and 903 total commits since `v2.5.1-stable.202605261941`.
 
 ### Rail, outline, and packages
 
@@ -165,17 +157,20 @@ The range currently contains 441 first-parent commits and 666 total commits sinc
 - save live widget state metadata ([644933e](https://github.com/nteract/nteract/commit/644933e8))
 - split widget comm state into `CommsDoc` ([13a5fe2](https://github.com/nteract/nteract/commit/13a5fe23))
 - project `CommsDoc` widget state to Python ([54339c1](https://github.com/nteract/nteract/commit/54339c12))
+- batch initial widget comm writes ([e3054ec](https://github.com/nteract/nteract/commit/e3054ec8))
 - hydrate widget progress views ([f640db7](https://github.com/nteract/nteract/commit/f640db7c))
 - resolve widget comm blobs ([d50887c](https://github.com/nteract/nteract/commit/d50887ca))
 - show stale widget snapshots ([a9bbc54](https://github.com/nteract/nteract/commit/a9bbc54e))
 
-### Markdown and TeX
+### Markdown, TeX, and document structure
 
 - project Markdown through Rust WASM ([5d4682e](https://github.com/nteract/nteract/commit/5d4682e1))
 - project bare TeX environments as math ([70d1006](https://github.com/nteract/nteract/commit/70d10061))
 - restore preview double-click editing ([5d337e7](https://github.com/nteract/nteract/commit/5d337e77))
 - keep document frames selectable ([449315f](https://github.com/nteract/nteract/commit/449315fd))
 - use markdown engine anchors for notebook outline ([9344e01](https://github.com/nteract/nteract/commit/9344e010))
+- keep markdown outline live after edits ([a0816b5](https://github.com/nteract/nteract/commit/a0816b54))
+- enable markdown spellcheck ([b30db7b](https://github.com/nteract/nteract/commit/b30db7b8))
 - refine document typography ([e113ccb](https://github.com/nteract/nteract/commit/e113ccb2))
 
 ### Notebook shell and ergonomics
@@ -188,10 +183,35 @@ The range currently contains 441 first-parent commits and 666 total commits sinc
 - soften hidden cell reveal rows ([5477469](https://github.com/nteract/nteract/commit/54774693))
 - quiet completed cell status ([335f0ab](https://github.com/nteract/nteract/commit/335f0ab9))
 - keep hidden cell keyboard navigation moving ([f2555da](https://github.com/nteract/nteract/commit/f2555da2))
+- preserve title editor caret order ([e918a2e](https://github.com/nteract/nteract/commit/e918a2ec))
+- preserve state across open and save-as ([f62d91e](https://github.com/nteract/nteract/commit/f62d91e6))
 
-### Cell editing and formatting
+### Cell editing, settings, and formatting
 
-- switch cell type between code and Markdown from the menus ([191aa48](https://github.com/nteract/nteract/commit/191aa484c))
-- add a setting to opt out of automatic ruff / deno fmt ([1f3d922](https://github.com/nteract/nteract/commit/1f3d92222))
+- switch cell type between code and Markdown from the menus ([191aa48](https://github.com/nteract/nteract/commit/191aa484))
+- add a setting to opt out of automatic ruff / deno fmt ([1f3d922](https://github.com/nteract/nteract/commit/1f3d9222))
+- route synced settings through notebook host ([e236938](https://github.com/nteract/nteract/commit/e2369380))
+- ignore stale synced settings callbacks ([a16db4e](https://github.com/nteract/nteract/commit/a16db4ed))
+
+### Outputs and runtime resilience
+
+- render Bokeh notebook MIME bundles ([a4b86f9](https://github.com/nteract/nteract/commit/a4b86f9d))
+- embed Bokeh renderer asset ([43b4fc4](https://github.com/nteract/nteract/commit/43b4fc40))
+- keep Bokeh renders stable across payload refreshes ([4fbdbd6](https://github.com/nteract/nteract/commit/4fbdbd65))
+- render Panel notebook bundles ([5171ccb](https://github.com/nteract/nteract/commit/5171ccb1))
+- copy image from a context menu on raster outputs ([b34b7fe](https://github.com/nteract/nteract/commit/b34b7fe6))
+- keep copy image inside the user gesture ([00e1ef7](https://github.com/nteract/nteract/commit/00e1ef74))
+- survive a daemon restart during initial materialize ([be922a8](https://github.com/nteract/nteract/commit/be922a86))
+- bound pool warmup timeouts ([08b4fe4](https://github.com/nteract/nteract/commit/08b4fe4f))
+
+### Comments preview
+
+- gate comments UI behind opt-in `enable_comments` ([a57b960](https://github.com/nteract/nteract/commit/a57b9609))
+- character-granular rendered highlight and run-derived display quote ([#3791](https://github.com/nteract/nteract/pull/3791))
+- rendered highlights activate their thread; author identity color and contrast ([#3792](https://github.com/nteract/nteract/pull/3792))
+- lighter discussion rail and single-field composer ([#3794](https://github.com/nteract/nteract/pull/3794))
+- multiple comment highlights per run and compose selection preview ([#3796](https://github.com/nteract/nteract/pull/3796))
+- ambiguous re-anchor refuses to guess ([#3797](https://github.com/nteract/nteract/pull/3797))
+- comments accessibility batch ([#3799](https://github.com/nteract/nteract/pull/3799))
 
 </details>

--- a/content/changelog/2.6.mdx
+++ b/content/changelog/2.6.mdx
@@ -61,13 +61,13 @@ Hopefully now you'll be able to know the environment you have without needing a 
 
 Markdown got more serious in 2.6.
 
-Bare TeX environments now project as math instead of plain text, completing compatibility with Jupyter notebooks. Write notebooks as they were intended, as a computational narrative that allows you to collaborate with others. Not just a pile of code cells.
-
 <LightboxImage
   src="https://img.runt.run/2026/06/2.6-markdown-tex.png"
   alt="A notebook rendering bare TeX as math: a list with inline math, equation-numbered align blocks, and display equations"
   className="my-10 w-full"
 />
+
+Bare TeX environments now project as math instead of plain text, completing compatibility with Jupyter notebooks. Write notebooks as they were intended, as a computational narrative that allows you to collaborate with others. Not just a pile of code cells.
 
 As part of this release, there's a new Rust/WASM markdown engine. Users don't have to know about it, but it creates steadier parsing, better outline anchors, and very fast rendering. I'm hoping the document experience can go further from here.
 

--- a/content/changelog/2.6.mdx
+++ b/content/changelog/2.6.mdx
@@ -27,8 +27,8 @@ This release makes me very proud. I redesigned the cell chrome, created a markdo
 ## Find your place in long notebooks
 
 <Video
-  src="https://img.runt.run/2026/06/2.6-outline-v2.mp4"
-  poster="https://img.runt.run/2026/06/2.6-outline-v2.png"
+  src="https://img.runt.run/2026/06/2.6-outline-v3.mp4"
+  poster="https://img.runt.run/2026/06/2.6-outline-v3.png"
   caption="The outline rail jumping between sections of a long notebook"
 />
 

--- a/content/changelog/2.6.mdx
+++ b/content/changelog/2.6.mdx
@@ -1,9 +1,9 @@
 ---
 version: "2.6"
-date: "2026-06-23T00:00:00Z"
+date: "2026-06-25T00:00:00Z"
 coversVersions:
   - "2.6.0"
-dateLabel: "Draft - June 23, 2026"
+dateLabel: "June 25, 2026"
 title: "Outline, Editing Controls, and Widget State"
 summary: "nteract 2.6 tightens the desktop notebook: a left-rail outline, package panels that stay out of the notebook body, stronger widget state restoration, better Markdown and TeX rendering, first-class code/Markdown cell conversion, and a setting to disable automatic formatting."
 highlights:
@@ -19,7 +19,7 @@ tags:
   - "packages"
   - "widgets"
   - "markdown"
-published: false
+published: true
 # githubReleaseUrl: "https://github.com/nteract/nteract/releases/tag/v2.6.0-stable.TODO"
 # heroImage: "https://img.runt.run/TODO/2.6-hero.png"
 # heroVideo: "https://img.runt.run/TODO/2.6-demo.mp4"

--- a/content/changelog/2.6.mdx
+++ b/content/changelog/2.6.mdx
@@ -80,8 +80,8 @@ After landing the rail work, it was clear there was opportunity to create cleare
 ### Motion on execution
 
 <Video
-  src="https://img.runt.run/2026/06/2.6-cell-motion-v2.mp4"
-  poster="https://img.runt.run/2026/06/2.6-cell-motion-v2.png"
+  src="https://img.runt.run/2026/06/2.6-cell-motion-v3.mp4"
+  poster="https://img.runt.run/2026/06/2.6-cell-motion-v3.png"
   caption="Execution, reveal, and focus transitions in the redesigned shell"
 />
 

--- a/content/changelog/2.6.mdx
+++ b/content/changelog/2.6.mdx
@@ -5,15 +5,17 @@ coversVersions:
   - "2.6.0"
 dateLabel: "Draft - June 10, 2026"
 title: "Table of Contents, Notebook Design, Widget State"
-summary: "The nteract 2.6 draft focuses the notebook workspace: a table of contents for long notebooks, package management in the rail, a more polished notebook shell, widget state that survives more of your work, and Markdown improvements including bare TeX rendering."
+summary: "The nteract 2.6 draft focuses the notebook workspace: a table of contents for long notebooks, package management in the rail, a more polished notebook shell, widget state that survives more of your work, Markdown including bare TeX, plus two from user feedback: switching a cell between code and Markdown from the menus, and an opt-out for automatic code formatting."
 highlights:
+  - "Switch a cell between code and Markdown from the context and main menus"
+  - "Turn off automatic code reformatting when you want your code left as written"
   - "Long notebooks now get an outline / table of contents"
   - "The notebook shell has new affordances, cleaner cell states, and more intentional motion"
   - "Widget state is saved and restored more reliably across notebook sessions"
-  - "Markdown rendering is backed by the Rust engine and now handles bare TeX environments"
 tags:
   - "notebook"
   - "design"
+  - "editing"
   - "packages"
   - "widgets"
   - "markdown"
@@ -95,8 +97,26 @@ There is new motion here too: not animation for decoration, but animation that h
 
 That may sound like vibes until you spend a day in the notebook. Then it becomes the difference between an app that constantly asks you to re-orient and an app that keeps you in the work.
 
+## Switch a cell between code and Markdown
+
+{/* TODO: capture the cell context menu showing the change-type entry. */}
+
+A cell should not be stuck as the type you first made it.
+
+2.6 makes switching a cell between code and Markdown a first-class move. Right-click a cell, or use the main menu, and change its type. Mostly that is the everyday loop of writing a notebook that is half prose and half computation: drop into Markdown to explain, back to code to compute, without deleting and recreating cells.
+
+The switch is an edit on the cell itself, so its place in the notebook and anything anchored to it come along for the ride. This one came straight from user feedback, and it is the kind of small thing you stop noticing precisely because it stopped getting in your way.
+
+## Formatting on your terms
+
+nteract can tidy code on its way in: `ruff` for Python, `deno fmt` for the rest. Some people love it. Some people want their code left exactly as written.
+
+2.6 adds a setting to turn automatic reformatting off. When it is off, the notebook stops rewriting code you did not ask it to touch. Auto-format stays the default for the people who like it, but it is no longer something the editor insists on. This closes a long-standing request ([#3795](https://github.com/nteract/nteract/issues/3795)).
+
 ## Things to finish before publishing
 
+- Land the two user-feedback add-ons (cell type switching, auto-format opt-out) and add their commits to the technical changelog.
+- Confirm the commenting UI is gated off for the 2.6 release channel (it launches publicly in 2.7).
 - Replace the draft date with the final release date.
 - Replace `coversVersions` with the actual 2.6 stable and patch versions.
 - Add the final `githubReleaseUrl`.

--- a/content/changelog/2.6.mdx
+++ b/content/changelog/2.6.mdx
@@ -4,14 +4,16 @@ date: "2026-06-10T00:00:00Z"
 coversVersions:
   - "2.6.0"
 dateLabel: "Draft - June 10, 2026"
-title: "Table of Contents, Package Management, Widget State"
-summary: "The nteract 2.6 draft focuses the notebook workspace: a table of contents for long notebooks, package management in the rail, widget state that survives more of your work, and Markdown improvements including bare TeX rendering."
+title: "Table of Contents, Notebook Design, Widget State"
+summary: "The nteract 2.6 draft focuses the notebook workspace: a table of contents for long notebooks, package management in the rail, a more polished notebook shell, widget state that survives more of your work, and Markdown improvements including bare TeX rendering."
 highlights:
   - "Long notebooks now get an outline / table of contents"
+  - "The notebook shell has new affordances, cleaner cell states, and more intentional motion"
   - "Widget state is saved and restored more reliably across notebook sessions"
   - "Markdown rendering is backed by the Rust engine and now handles bare TeX environments"
 tags:
   - "notebook"
+  - "design"
   - "packages"
   - "widgets"
   - "markdown"
@@ -37,7 +39,7 @@ Before publishing 2.6, refresh the clone, replace the head commit with the final
 
 2.6 is the release where the notebook gets more shape around the work you are already doing.
 
-2.5 made outputs feel richer: navigable tracebacks, explorable DataFrames, and secrets that stay out of notebook output. 2.6 is quieter, but it is the kind of quiet that matters after a few hours in the same notebook. Navigation moves closer. Packages stop competing with the page. Widgets remember more. Markdown behaves more like a document.
+2.5 made outputs feel richer: navigable tracebacks, explorable DataFrames, and secrets that stay out of notebook output. 2.6 is quieter, but it is the kind of quiet that matters after a few hours in the same notebook. Navigation moves closer. Packages stop competing with the page. Cell states get clearer. The shell has more intentional affordances and motion. Widgets remember more. Markdown behaves more like a document.
 
 This is a notebook ergonomics release.
 
@@ -83,9 +85,15 @@ The Markdown path is also moving through the Rust/WASM markdown engine. Users pr
 
 ## A better notebook shell
 
-A lot of the 2.6 work sits just below the surface: shared rail pieces, shell capabilities, quieter execution affordances, better hidden-cell language, shared package summaries, and a more consistent NotebookView.
+{/* TODO: add a short clip that shows the new cell affordances and animations in motion. */}
 
-That may sound like internal plumbing, but it shows up in the app as fewer weird edges. Read-only markdown still navigates. Structure edits gate themselves on host support. The rail can carry more responsibility. The notebook body gets to stay the notebook body.
+There is a lot of new design work in 2.6, and I do not want it to disappear under the word "polish."
+
+The notebook shell has better affordances for what you can do, what state a cell is in, and where the next action lives. Hidden cells have clearer language. Completed cells quiet down. Structure edits gate themselves on host support. The rail can carry more responsibility. The notebook body gets to stay the notebook body.
+
+There is new motion here too: not animation for decoration, but animation that helps the notebook explain itself. Execution, reveal, focus, and shell transitions can feel less abrupt when the interface has a little choreography.
+
+That may sound like vibes until you spend a day in the notebook. Then it becomes the difference between an app that constantly asks you to re-orient and an app that keeps you in the work.
 
 ## Things to finish before publishing
 
@@ -145,6 +153,7 @@ The range currently contains 441 first-parent commits and 666 total commits sinc
 - add capability-scoped document header ([fdf13aa](https://github.com/nteract/nteract/commit/fdf13aae))
 - drive `NotebookView` from shell capabilities ([8af8135](https://github.com/nteract/nteract/commit/8af81352))
 - gate run controls on host-neutral runtime availability ([4cb2b76](https://github.com/nteract/nteract/commit/4cb2b766))
+- stage execution signal animation ([fdac721](https://github.com/nteract/nteract/commit/fdac721d))
 - refine hidden and output surfaces ([5b5fda8](https://github.com/nteract/nteract/commit/5b5fda8f))
 - soften hidden cell reveal rows ([5477469](https://github.com/nteract/nteract/commit/54774693))
 - quiet completed cell status ([335f0ab](https://github.com/nteract/nteract/commit/335f0ab9))

--- a/content/changelog/2.6.mdx
+++ b/content/changelog/2.6.mdx
@@ -4,10 +4,10 @@ date: "2026-06-10T00:00:00Z"
 coversVersions:
   - "2.6.0"
 dateLabel: "Draft - June 10, 2026"
-title: "Outline Rail, Package Management, Widget State"
-summary: "The nteract 2.6 draft focuses the notebook workspace: a left rail with outline and packages, widget state that survives more of your work, and Markdown improvements including bare TeX rendering."
+title: "Table of Contents, Package Management, Widget State"
+summary: "The nteract 2.6 draft focuses the notebook workspace: a table of contents for long notebooks, package management in the rail, widget state that survives more of your work, and Markdown improvements including bare TeX rendering."
 highlights:
-  - "The left rail now carries the notebook outline and package management"
+  - "Long notebooks now get an outline / table of contents"
   - "Widget state is saved and restored more reliably across notebook sessions"
   - "Markdown rendering is backed by the Rust engine and now handles bare TeX environments"
 tags:
@@ -41,13 +41,13 @@ Before publishing 2.6, refresh the clone, replace the head commit with the final
 
 This is a notebook ergonomics release.
 
-## The rail has a job now
+## Table of Contents
 
 {/* TODO: add a screenshot or short clip of the left rail switching between outline and package panels. */}
 
-The left rail now carries the notebook outline.
+Long notebooks now get an outline in the left rail.
 
-That sounds small until you are in a long notebook and every heading has become a landmark. Instead of scrolling by vibes, you can skim the document structure, jump between sections, and keep the notebook body focused on the cells themselves.
+That sounds small until every heading has become a landmark. Instead of scrolling by vibes, you can skim the document structure, jump between sections, and keep the notebook body focused on the cells themselves.
 
 The rail also gives package management a better home. Package state belongs near the notebook, but it does not need to live in the notebook body. Moving package management into the rail makes the environment feel attached to the work without turning dependency management into another cell-shaped distraction.
 

--- a/content/changelog/2.7.mdx
+++ b/content/changelog/2.7.mdx
@@ -1,140 +1,95 @@
 ---
 version: "2.7"
-date: "2026-06-10T00:00:01Z"
+date: "2026-07-01T00:00:00Z"
 coversVersions:
   - "2.7.0"
 dateLabel: "Unreleased draft"
-title: "Hosted Notebooks, Workstations, and Runtime Peers"
-summary: "A holding draft for the hosted notebook and workstation-compute story: shared rooms, owner-run execution, runtime peers, faster hosted outputs, and MCP resources."
+title: "Comments on the Notebook"
+summary: "2.7 makes the notebook something you can talk about in place: comments anchored to exact source and rendered Markdown, run-derived quotes that survive edits, a discussion rail, and clear authorship for the people and agents working in the same document."
 highlights:
-  - "Hosted notebooks can become shared rooms with owner-controlled editing and execution"
-  - "Runtime peers and workstations attach real compute to browser-hosted notebooks"
-  - "Hosted outputs, widgets, publishing, and MCP resources are moving toward the same notebook state"
+  - "Comment on an exact selection, in both the source editor and rendered Markdown"
+  - "Quotes are derived from what you selected and re-anchor by content, dangling honestly when they can't"
+  - "A lighter discussion rail with on-demand replies and a single-field composer"
+  - "Every comment carries its author's identity, so you can tell a teammate from an agent at a glance"
 tags:
-  - "cloud"
-  - "workstations"
-  - "sharing"
-  - "mcp"
+  - "notebook"
+  - "comments"
+  - "collaboration"
+  - "review"
 published: false
 # githubReleaseUrl: "https://github.com/nteract/nteract/releases/tag/v2.7.0-stable.TODO"
 # heroImage: "https://img.runt.run/TODO/2.7-hero.png"
 # heroVideo: "https://img.runt.run/TODO/2.7-demo.mp4"
 ---
 
-{/* 
-Unreleased holding draft.
+{/*
+Unreleased draft for the public commenting release.
 
-Do not publish until the cloud offering is public and stable enough to market. As of 2026-06-10 this work is hosted on preview.runt.run but not release-ready.
+The commenting layer is merged to main (PRs #3791, #3792, #3794, #3796, #3797,
+#3799, #3800) but is held for a public 2.7 launch. Before publishing: confirm the
+comments UI is enabled for the release channel, refresh the commit range against
+the final tag, and capture hero media of a real comment thread.
 
-Source material moved out of the first 2.6 prep draft after the release positioning changed.
-
-Release prep range, generated from /Users/kylekelley/code/src/github.com/nteract/nteract on 2026-06-10:
-
-Base: v2.5.1-stable.202605261941
-Base commit: 4867b005ac89d1ce28775c27a33f379da0d0f50e
-Head: origin/main
-Head commit: f6fba37ee12c414937859760b7fb59b2a4db7469
-Range: 4867b005ac89d1ce28775c27a33f379da0d0f50e..f6fba37ee12c414937859760b7fb59b2a4db7469
-
-Before publishing, refresh this against the final release tag and remove anything that shipped in 2.6.
+Cloud / hosted-notebook material lives in content/changelog/_cloud-holding.mdx,
+deferred behind this release.
 */}
 
-This is the release story for hosted notebooks once the cloud offering is ready to talk about publicly.
+2.7 is the release where you can talk about a notebook inside the notebook.
 
-The premise is still right: the browser notebook should stop feeling like a read-only postcard from the desktop app. Hosted notebooks should become rooms you can share, edit, execute, publish, and hand to tools without inventing a second notebook model.
+Notebooks have always been collaborative in spirit and lonely in practice. You could share the file, but the conversation happened somewhere else: a thread, a call, a review tool that knew nothing about cells. 2.7 brings the conversation into the document and anchors it to the thing you are actually pointing at.
 
-It is just not the 2.6 story.
+This is the commenting layer. It is built to feel like commenting on a document, but it understands that the document is a live notebook.
 
-## Hosted notebooks you can keep using
+## Comment on what you mean
 
-{/* TODO: add a short video showing a hosted notebook moving between viewer/editor modes, sharing controls, and live output updates. */}
+Select a phrase, a variable, a line of a traceback, a sentence of Markdown prose, and comment on exactly that. Highlights are character-granular, not whole-cell. The selection you made is the selection the comment remembers.
 
-Hosted notebooks are gaining real room mechanics behind them. Owners can share notebooks, grant edit access, accept authenticated viewers, and keep browser sessions attached without turning every link into a one-off artifact.
+It works in both planes. In the source editor you can highlight inside code or raw Markdown. In rendered Markdown you can highlight the prose as it reads, and the comment maps back to the underlying source. A notebook that is half writing and half computation gets one commenting model across both.
 
-The cloud app has learned about app sessions, owner-gated sharing controls, edit access requests, invite storage, friendlier presence labels, and hosted widget state that survives more of the weird browser edges.
+## Quotes that follow the edits
 
-The target is boring in the best way: a hosted notebook should feel like a notebook you can keep using.
+A comment stores the text you selected, and that quote is how it finds its place again. Edit the cell, move things around, and the comment re-anchors to its quote rather than to a brittle line-and-column.
 
-## Run it from the cloud, keep the runtime yours
+When the text genuinely changed and there is no confident place to land, the comment dangles instead of guessing. A wrong anchor is worse than an honest "this moved." Comments only re-attach when the surrounding context actually disambiguates where they belong.
 
-{/* TODO: add a demo clip of starting workstation compute from the hosted toolbar. */}
+## A discussion rail, not a sidebar dump
 
-The cloud work starts connecting hosted notebooks to real compute instead of pretending the viewer is the runtime.
+The discussion rail is deliberately quiet. Threads read as a flowing list rather than a stack of bordered boxes. Replies are on-demand: a thread shows its conversation, and the composer appears when you decide to add to it.
 
-Runtime peers can attach to hosted rooms, accept execution intent, reconnect, re-auth, and publish their state back to the room. Workstations show up in the document rail and can be started from the hosted toolbar. There is a one-liner workstation install path in the current range, plus Anaconda API key support for the hosted side of the flow.
+The composer is a single field with the send control inside it, tinted with your author color. The quote header doubles as the way back to the highlight in the document. Cmd+Enter sends. It is meant to get out of the way of the actual notebook.
 
-This is the shape I want for cloud notebooks: the browser owns the collaboration and sharing surface, but the runtime stays explicit. You can see when compute is offline, when a peer is attached, and when a room is waiting on a runtime instead of guessing.
+## Who is talking
 
-## One notebook state
+Every comment carries its author's identity as a color, with readable contrast computed for whatever that color is. That sounds cosmetic until a notebook has more than one voice in it.
 
-The desktop app and hosted cloud used to look related, but too much of the notebook chrome and state flow was duplicated. The cloud work cuts that down.
+This matters most as agents start working in the same document as people. When a tool acts on your behalf, its comments should be legible as its comments, distinct from yours, not laundered into an anonymous gray. nteract is built for humans, kernels, and agents on the same live notebook; the commenting layer treats agent authorship as a first-class identity rather than an afterthought.
 
-The notebook view now shares more of its shell: the rail, capability model, headers, host notices, package summaries, search, environment panels, hidden-cell affordances, output focus, and execution language. That sounds internal, but it changes how the app feels. The cloud notebook and the desktop notebook are now arguing less about what a notebook is.
+## You can turn it off
 
-## Hosted publishing gets faster
-
-{/* TODO: add a before/after clip or timing capture for hosted output hydration. */}
-
-The viewer path has picked up a serious round of performance work.
-
-Hosted notebooks defer and stage more of the expensive output work: lazy output frame mounting, progressive output hydration, runtime WASM preloads, Sift WASM preloads, sidecar renderer assets, hosted output blob caching, viewer CSS splitting, and incremental live runtime projections.
-
-The user-facing version is simple: shared notebooks should load the notebook first, then get richer as the expensive pieces arrive. No one should wait for every widget, frame, stylesheet, and blob before reading the first cell.
-
-## MCP reads the notebook, not a shadow notebook
-
-MCP and agent surfaces are becoming more notebook-native.
-
-Cell reads prefer resources. Client display names are canonicalized. Generated icons are advertised. Proxy recovery messages are more install-aware. The notebook tool bridge is exposed from `runt`, and the hosted/browser runtime work gives agents a clearer route into the same notebook state a human sees.
-
-That is the part I care about most: tools should not need a parallel notebook model. They should read cells, outputs, identities, and runtime state from the same documents the app is already using.
+Comments ship behind a single switch. Deployments that do not want the commenting UI can disable it in one place, and the surface, the rail, the gutter affordance, the context-menu entries, the composer, goes away cleanly, without unwiring the underlying sync. The launch default is on; the off switch is there for environments that need it.
 
 ## Working technical changelog
 
 <details>
-<summary>Current cloud/workstation draft notes</summary>
+<summary>Commenting layer (merged to main, held for 2.7)</summary>
 
-This section is a prep scaffold, not the final generated changelog.
+This section is a prep scaffold, not the final generated changelog. The range
+will be regenerated against the 2.7 stable tag before publishing.
 
-### Hosted notebooks and sharing
+### Anchoring and quotes
 
-- add hosted sharing controls ([cbe800f](https://github.com/nteract/nteract/commit/cbe800f4))
-- add hosted edit access requests ([67d0fcd](https://github.com/nteract/nteract/commit/67d0fcda))
-- grant editors full cell editing in hosted rooms ([956cce9](https://github.com/nteract/nteract/commit/956cce97))
-- render hosted notebooks through `NotebookView` ([2723268](https://github.com/nteract/nteract/commit/27232684))
-- bootstrap notebook home with app sessions ([5162237](https://github.com/nteract/nteract/commit/51622379))
-- polish notebook home and workstation panel ([5cb944c](https://github.com/nteract/nteract/commit/5cb944c1))
-- gate sharing controls to owners ([790b759](https://github.com/nteract/nteract/commit/790b7591))
+- character-granular rendered highlight + run-derived display quote ([#3791](https://github.com/nteract/nteract/pull/3791))
+- multiple comment highlights per run + compose selection preview ([#3796](https://github.com/nteract/nteract/pull/3796))
+- ambiguous re-anchor refuses to guess (dangle instead) ([#3797](https://github.com/nteract/nteract/pull/3797))
 
-### Runtime peers and workstations
+### Rail, composer, and identity
 
-- add `runt publish` helper ([39c7acc](https://github.com/nteract/nteract/commit/39c7acc5))
-- accept Anaconda API keys ([61ccd18](https://github.com/nteract/nteract/commit/61ccd186))
-- add preview OIDC login ([4444f9f](https://github.com/nteract/nteract/commit/4444f9fc))
-- add cloud runtime lifecycle ([809cf01](https://github.com/nteract/nteract/commit/809cf01e))
-- add transport-agnostic `runtime_agent` and cloud WebSocket transport ([9c87bd0](https://github.com/nteract/nteract/commit/9c87bd01))
-- add daemon workstation endpoint ([8660705](https://github.com/nteract/nteract/commit/86607050))
-- register hosted workstations ([b3b10f5](https://github.com/nteract/nteract/commit/b3b10f59))
-- project workstation launch contract ([c100d41](https://github.com/nteract/nteract/commit/c100d414))
-- start workstation compute from the toolbar ([ddbaa4e](https://github.com/nteract/nteract/commit/ddbaa4e7))
+- rendered highlights activate their thread; author identity color + contrast ([#3792](https://github.com/nteract/nteract/pull/3792))
+- lighter, Discord-style discussion rail and single-field composer ([#3794](https://github.com/nteract/nteract/pull/3794))
 
-### Hosted viewer and output loading
+### Accessibility and gating
 
-- preload Sift WASM for live views ([cf8172a](https://github.com/nteract/nteract/commit/cf8172a3))
-- hydrate hosted outputs progressively ([d16326e](https://github.com/nteract/nteract/commit/d16326e1))
-- load renderer from sidecar assets ([98663df](https://github.com/nteract/nteract/commit/98663df4))
-- defer supplemental viewer CSS ([a6e94b2](https://github.com/nteract/nteract/commit/a6e94b2e))
-- stage async output resolution ([8f32259](https://github.com/nteract/nteract/commit/8f322592))
-- lazy mount output frames ([91f3977](https://github.com/nteract/nteract/commit/91f3977d))
-- cache hosted output blobs ([5499951](https://github.com/nteract/nteract/commit/5499951d))
-- project live runtime updates incrementally ([679c6ae](https://github.com/nteract/nteract/commit/679c6ae2))
-
-### MCP, agents, and tooling
-
-- canonicalize MCP client display names ([c9f24ae](https://github.com/nteract/nteract/commit/c9f24ae3))
-- advertise generated MCP icons ([b6b6db7](https://github.com/nteract/nteract/commit/b6b6db78))
-- prefer resources for cell reads ([689034e](https://github.com/nteract/nteract/commit/689034e9))
-- expose notebook tool bridge ([497a3fa](https://github.com/nteract/nteract/commit/497a3fa7))
-- make proxy recovery messages install-aware ([c84481d](https://github.com/nteract/nteract/commit/c84481d6))
+- a11y batch: keyboard-reachable output comments, composer focus restore, rail Escape, end-exclusive hit-test ([#3799](https://github.com/nteract/nteract/pull/3799))
+- `disable_comments` feature flag gating the comments UI from one place ([#3800](https://github.com/nteract/nteract/pull/3800))
 
 </details>

--- a/content/changelog/2.7.mdx
+++ b/content/changelog/2.7.mdx
@@ -1,0 +1,140 @@
+---
+version: "2.7"
+date: "2026-06-10T00:00:01Z"
+coversVersions:
+  - "2.7.0"
+dateLabel: "Unreleased draft"
+title: "Hosted Notebooks, Workstations, and Runtime Peers"
+summary: "A holding draft for the hosted notebook and workstation-compute story: shared rooms, owner-run execution, runtime peers, faster hosted outputs, and MCP resources."
+highlights:
+  - "Hosted notebooks can become shared rooms with owner-controlled editing and execution"
+  - "Runtime peers and workstations attach real compute to browser-hosted notebooks"
+  - "Hosted outputs, widgets, publishing, and MCP resources are moving toward the same notebook state"
+tags:
+  - "cloud"
+  - "workstations"
+  - "sharing"
+  - "mcp"
+published: false
+# githubReleaseUrl: "https://github.com/nteract/nteract/releases/tag/v2.7.0-stable.TODO"
+# heroImage: "https://img.runt.run/TODO/2.7-hero.png"
+# heroVideo: "https://img.runt.run/TODO/2.7-demo.mp4"
+---
+
+{/* 
+Unreleased holding draft.
+
+Do not publish until the cloud offering is public and stable enough to market. As of 2026-06-10 this work is hosted on preview.runt.run but not release-ready.
+
+Source material moved out of the first 2.6 prep draft after the release positioning changed.
+
+Release prep range, generated from /Users/kylekelley/code/src/github.com/nteract/nteract on 2026-06-10:
+
+Base: v2.5.1-stable.202605261941
+Base commit: 4867b005ac89d1ce28775c27a33f379da0d0f50e
+Head: origin/main
+Head commit: f6fba37ee12c414937859760b7fb59b2a4db7469
+Range: 4867b005ac89d1ce28775c27a33f379da0d0f50e..f6fba37ee12c414937859760b7fb59b2a4db7469
+
+Before publishing, refresh this against the final release tag and remove anything that shipped in 2.6.
+*/}
+
+This is the release story for hosted notebooks once the cloud offering is ready to talk about publicly.
+
+The premise is still right: the browser notebook should stop feeling like a read-only postcard from the desktop app. Hosted notebooks should become rooms you can share, edit, execute, publish, and hand to tools without inventing a second notebook model.
+
+It is just not the 2.6 story.
+
+## Hosted notebooks you can keep using
+
+{/* TODO: add a short video showing a hosted notebook moving between viewer/editor modes, sharing controls, and live output updates. */}
+
+Hosted notebooks are gaining real room mechanics behind them. Owners can share notebooks, grant edit access, accept authenticated viewers, and keep browser sessions attached without turning every link into a one-off artifact.
+
+The cloud app has learned about app sessions, owner-gated sharing controls, edit access requests, invite storage, friendlier presence labels, and hosted widget state that survives more of the weird browser edges.
+
+The target is boring in the best way: a hosted notebook should feel like a notebook you can keep using.
+
+## Run it from the cloud, keep the runtime yours
+
+{/* TODO: add a demo clip of starting workstation compute from the hosted toolbar. */}
+
+The cloud work starts connecting hosted notebooks to real compute instead of pretending the viewer is the runtime.
+
+Runtime peers can attach to hosted rooms, accept execution intent, reconnect, re-auth, and publish their state back to the room. Workstations show up in the document rail and can be started from the hosted toolbar. There is a one-liner workstation install path in the current range, plus Anaconda API key support for the hosted side of the flow.
+
+This is the shape I want for cloud notebooks: the browser owns the collaboration and sharing surface, but the runtime stays explicit. You can see when compute is offline, when a peer is attached, and when a room is waiting on a runtime instead of guessing.
+
+## One notebook state
+
+The desktop app and hosted cloud used to look related, but too much of the notebook chrome and state flow was duplicated. The cloud work cuts that down.
+
+The notebook view now shares more of its shell: the rail, capability model, headers, host notices, package summaries, search, environment panels, hidden-cell affordances, output focus, and execution language. That sounds internal, but it changes how the app feels. The cloud notebook and the desktop notebook are now arguing less about what a notebook is.
+
+## Hosted publishing gets faster
+
+{/* TODO: add a before/after clip or timing capture for hosted output hydration. */}
+
+The viewer path has picked up a serious round of performance work.
+
+Hosted notebooks defer and stage more of the expensive output work: lazy output frame mounting, progressive output hydration, runtime WASM preloads, Sift WASM preloads, sidecar renderer assets, hosted output blob caching, viewer CSS splitting, and incremental live runtime projections.
+
+The user-facing version is simple: shared notebooks should load the notebook first, then get richer as the expensive pieces arrive. No one should wait for every widget, frame, stylesheet, and blob before reading the first cell.
+
+## MCP reads the notebook, not a shadow notebook
+
+MCP and agent surfaces are becoming more notebook-native.
+
+Cell reads prefer resources. Client display names are canonicalized. Generated icons are advertised. Proxy recovery messages are more install-aware. The notebook tool bridge is exposed from `runt`, and the hosted/browser runtime work gives agents a clearer route into the same notebook state a human sees.
+
+That is the part I care about most: tools should not need a parallel notebook model. They should read cells, outputs, identities, and runtime state from the same documents the app is already using.
+
+## Working technical changelog
+
+<details>
+<summary>Current cloud/workstation draft notes</summary>
+
+This section is a prep scaffold, not the final generated changelog.
+
+### Hosted notebooks and sharing
+
+- add hosted sharing controls ([cbe800f](https://github.com/nteract/nteract/commit/cbe800f4))
+- add hosted edit access requests ([67d0fcd](https://github.com/nteract/nteract/commit/67d0fcda))
+- grant editors full cell editing in hosted rooms ([956cce9](https://github.com/nteract/nteract/commit/956cce97))
+- render hosted notebooks through `NotebookView` ([2723268](https://github.com/nteract/nteract/commit/27232684))
+- bootstrap notebook home with app sessions ([5162237](https://github.com/nteract/nteract/commit/51622379))
+- polish notebook home and workstation panel ([5cb944c](https://github.com/nteract/nteract/commit/5cb944c1))
+- gate sharing controls to owners ([790b759](https://github.com/nteract/nteract/commit/790b7591))
+
+### Runtime peers and workstations
+
+- add `runt publish` helper ([39c7acc](https://github.com/nteract/nteract/commit/39c7acc5))
+- accept Anaconda API keys ([61ccd18](https://github.com/nteract/nteract/commit/61ccd186))
+- add preview OIDC login ([4444f9f](https://github.com/nteract/nteract/commit/4444f9fc))
+- add cloud runtime lifecycle ([809cf01](https://github.com/nteract/nteract/commit/809cf01e))
+- add transport-agnostic `runtime_agent` and cloud WebSocket transport ([9c87bd0](https://github.com/nteract/nteract/commit/9c87bd01))
+- add daemon workstation endpoint ([8660705](https://github.com/nteract/nteract/commit/86607050))
+- register hosted workstations ([b3b10f5](https://github.com/nteract/nteract/commit/b3b10f59))
+- project workstation launch contract ([c100d41](https://github.com/nteract/nteract/commit/c100d414))
+- start workstation compute from the toolbar ([ddbaa4e](https://github.com/nteract/nteract/commit/ddbaa4e7))
+
+### Hosted viewer and output loading
+
+- preload Sift WASM for live views ([cf8172a](https://github.com/nteract/nteract/commit/cf8172a3))
+- hydrate hosted outputs progressively ([d16326e](https://github.com/nteract/nteract/commit/d16326e1))
+- load renderer from sidecar assets ([98663df](https://github.com/nteract/nteract/commit/98663df4))
+- defer supplemental viewer CSS ([a6e94b2](https://github.com/nteract/nteract/commit/a6e94b2e))
+- stage async output resolution ([8f32259](https://github.com/nteract/nteract/commit/8f322592))
+- lazy mount output frames ([91f3977](https://github.com/nteract/nteract/commit/91f3977d))
+- cache hosted output blobs ([5499951](https://github.com/nteract/nteract/commit/5499951d))
+- project live runtime updates incrementally ([679c6ae](https://github.com/nteract/nteract/commit/679c6ae2))
+
+### MCP, agents, and tooling
+
+- canonicalize MCP client display names ([c9f24ae](https://github.com/nteract/nteract/commit/c9f24ae3))
+- advertise generated MCP icons ([b6b6db7](https://github.com/nteract/nteract/commit/b6b6db78))
+- prefer resources for cell reads ([689034e](https://github.com/nteract/nteract/commit/689034e9))
+- expose notebook tool bridge ([497a3fa](https://github.com/nteract/nteract/commit/497a3fa7))
+- make proxy recovery messages install-aware ([c84481d](https://github.com/nteract/nteract/commit/c84481d6))
+
+</details>

--- a/content/changelog/2.7.mdx
+++ b/content/changelog/2.7.mdx
@@ -66,7 +66,7 @@ This matters most as agents start working in the same document as people. When a
 
 ## You can turn it off
 
-Comments ship behind a single switch. Deployments that do not want the commenting UI can disable it in one place, and the surface, the rail, the gutter affordance, the context-menu entries, the composer, goes away cleanly, without unwiring the underlying sync. The launch default is on; the off switch is there for environments that need it.
+Comments ship behind a single switch. The 2.6 preview is opt-in, and deployments that do not want the commenting UI can keep the surface out of the way in one place: the rail, gutter affordance, context-menu entries, and composer all disappear cleanly without unwiring the underlying sync. The intended 2.7 launch default is on; the switch remains there for environments that need it.
 
 ## Working technical changelog
 
@@ -90,6 +90,6 @@ will be regenerated against the 2.7 stable tag before publishing.
 ### Accessibility and gating
 
 - a11y batch: keyboard-reachable output comments, composer focus restore, rail Escape, end-exclusive hit-test ([#3799](https://github.com/nteract/nteract/pull/3799))
-- `disable_comments` feature flag gating the comments UI from one place ([#3800](https://github.com/nteract/nteract/pull/3800))
+- comments UI gating from one place, now exposed as the opt-in `enable_comments` preview flag ([#3800](https://github.com/nteract/nteract/pull/3800), [#3804](https://github.com/nteract/nteract/pull/3804))
 
 </details>

--- a/content/changelog/_cloud-holding.mdx
+++ b/content/changelog/_cloud-holding.mdx
@@ -1,0 +1,147 @@
+---
+version: "cloud-unreleased"
+date: "2026-06-10T00:00:01Z"
+coversVersions:
+  - "cloud-unreleased"
+dateLabel: "Deferred holding draft"
+title: "Hosted Notebooks, Workstations, and Runtime Peers"
+summary: "A holding draft for the hosted notebook and workstation-compute story: shared rooms, owner-run execution, runtime peers, faster hosted outputs, and MCP resources."
+highlights:
+  - "Hosted notebooks can become shared rooms with owner-controlled editing and execution"
+  - "Runtime peers and workstations attach real compute to browser-hosted notebooks"
+  - "Hosted outputs, widgets, publishing, and MCP resources are moving toward the same notebook state"
+tags:
+  - "cloud"
+  - "workstations"
+  - "sharing"
+  - "mcp"
+published: false
+# githubReleaseUrl: "https://github.com/nteract/nteract/releases/tag/v2.7.0-stable.TODO"
+# heroImage: "https://img.runt.run/TODO/2.7-hero.png"
+# heroVideo: "https://img.runt.run/TODO/2.7-demo.mp4"
+---
+
+{/* 
+Deferred holding draft. The leading underscore in the filename keeps this file
+out of the changelog loader (see lib/changelog.ts: it skips files starting with
+"_"), so it never renders and its frontmatter version is a placeholder, not a
+real release slot.
+
+Do not publish until the cloud offering is public and stable enough to market.
+As of 2026-06 this work is hosted on preview.runt.run but not release-ready, and
+it now sits behind both the 2.6 ergonomics release and the 2.7 commenting
+release. When cloud is ready, copy this back to a numbered NN.mdx, refresh the
+range against the final tag, and remove anything that shipped earlier.
+
+Source material moved out of the first 2.6 prep draft after the release positioning changed.
+
+Release prep range, generated from /Users/kylekelley/code/src/github.com/nteract/nteract on 2026-06-10:
+
+Base: v2.5.1-stable.202605261941
+Base commit: 4867b005ac89d1ce28775c27a33f379da0d0f50e
+Head: origin/main
+Head commit: f6fba37ee12c414937859760b7fb59b2a4db7469
+Range: 4867b005ac89d1ce28775c27a33f379da0d0f50e..f6fba37ee12c414937859760b7fb59b2a4db7469
+
+Before publishing, refresh this against the final release tag and remove anything that shipped in 2.6.
+*/}
+
+This is the release story for hosted notebooks once the cloud offering is ready to talk about publicly.
+
+The premise is still right: the browser notebook should stop feeling like a read-only postcard from the desktop app. Hosted notebooks should become rooms you can share, edit, execute, publish, and hand to tools without inventing a second notebook model.
+
+It is just not the 2.6 story.
+
+## Hosted notebooks you can keep using
+
+{/* TODO: add a short video showing a hosted notebook moving between viewer/editor modes, sharing controls, and live output updates. */}
+
+Hosted notebooks are gaining real room mechanics behind them. Owners can share notebooks, grant edit access, accept authenticated viewers, and keep browser sessions attached without turning every link into a one-off artifact.
+
+The cloud app has learned about app sessions, owner-gated sharing controls, edit access requests, invite storage, friendlier presence labels, and hosted widget state that survives more of the weird browser edges.
+
+The target is boring in the best way: a hosted notebook should feel like a notebook you can keep using.
+
+## Run it from the cloud, keep the runtime yours
+
+{/* TODO: add a demo clip of starting workstation compute from the hosted toolbar. */}
+
+The cloud work starts connecting hosted notebooks to real compute instead of pretending the viewer is the runtime.
+
+Runtime peers can attach to hosted rooms, accept execution intent, reconnect, re-auth, and publish their state back to the room. Workstations show up in the document rail and can be started from the hosted toolbar. There is a one-liner workstation install path in the current range, plus Anaconda API key support for the hosted side of the flow.
+
+This is the shape I want for cloud notebooks: the browser owns the collaboration and sharing surface, but the runtime stays explicit. You can see when compute is offline, when a peer is attached, and when a room is waiting on a runtime instead of guessing.
+
+## One notebook state
+
+The desktop app and hosted cloud used to look related, but too much of the notebook chrome and state flow was duplicated. The cloud work cuts that down.
+
+The notebook view now shares more of its shell: the rail, capability model, headers, host notices, package summaries, search, environment panels, hidden-cell affordances, output focus, and execution language. That sounds internal, but it changes how the app feels. The cloud notebook and the desktop notebook are now arguing less about what a notebook is.
+
+## Hosted publishing gets faster
+
+{/* TODO: add a before/after clip or timing capture for hosted output hydration. */}
+
+The viewer path has picked up a serious round of performance work.
+
+Hosted notebooks defer and stage more of the expensive output work: lazy output frame mounting, progressive output hydration, runtime WASM preloads, Sift WASM preloads, sidecar renderer assets, hosted output blob caching, viewer CSS splitting, and incremental live runtime projections.
+
+The user-facing version is simple: shared notebooks should load the notebook first, then get richer as the expensive pieces arrive. No one should wait for every widget, frame, stylesheet, and blob before reading the first cell.
+
+## MCP reads the notebook, not a shadow notebook
+
+MCP and agent surfaces are becoming more notebook-native.
+
+Cell reads prefer resources. Client display names are canonicalized. Generated icons are advertised. Proxy recovery messages are more install-aware. The notebook tool bridge is exposed from `runt`, and the hosted/browser runtime work gives agents a clearer route into the same notebook state a human sees.
+
+That is the part I care about most: tools should not need a parallel notebook model. They should read cells, outputs, identities, and runtime state from the same documents the app is already using.
+
+## Working technical changelog
+
+<details>
+<summary>Current cloud/workstation draft notes</summary>
+
+This section is a prep scaffold, not the final generated changelog.
+
+### Hosted notebooks and sharing
+
+- add hosted sharing controls ([cbe800f](https://github.com/nteract/nteract/commit/cbe800f4))
+- add hosted edit access requests ([67d0fcd](https://github.com/nteract/nteract/commit/67d0fcda))
+- grant editors full cell editing in hosted rooms ([956cce9](https://github.com/nteract/nteract/commit/956cce97))
+- render hosted notebooks through `NotebookView` ([2723268](https://github.com/nteract/nteract/commit/27232684))
+- bootstrap notebook home with app sessions ([5162237](https://github.com/nteract/nteract/commit/51622379))
+- polish notebook home and workstation panel ([5cb944c](https://github.com/nteract/nteract/commit/5cb944c1))
+- gate sharing controls to owners ([790b759](https://github.com/nteract/nteract/commit/790b7591))
+
+### Runtime peers and workstations
+
+- add `runt publish` helper ([39c7acc](https://github.com/nteract/nteract/commit/39c7acc5))
+- accept Anaconda API keys ([61ccd18](https://github.com/nteract/nteract/commit/61ccd186))
+- add preview OIDC login ([4444f9f](https://github.com/nteract/nteract/commit/4444f9fc))
+- add cloud runtime lifecycle ([809cf01](https://github.com/nteract/nteract/commit/809cf01e))
+- add transport-agnostic `runtime_agent` and cloud WebSocket transport ([9c87bd0](https://github.com/nteract/nteract/commit/9c87bd01))
+- add daemon workstation endpoint ([8660705](https://github.com/nteract/nteract/commit/86607050))
+- register hosted workstations ([b3b10f5](https://github.com/nteract/nteract/commit/b3b10f59))
+- project workstation launch contract ([c100d41](https://github.com/nteract/nteract/commit/c100d414))
+- start workstation compute from the toolbar ([ddbaa4e](https://github.com/nteract/nteract/commit/ddbaa4e7))
+
+### Hosted viewer and output loading
+
+- preload Sift WASM for live views ([cf8172a](https://github.com/nteract/nteract/commit/cf8172a3))
+- hydrate hosted outputs progressively ([d16326e](https://github.com/nteract/nteract/commit/d16326e1))
+- load renderer from sidecar assets ([98663df](https://github.com/nteract/nteract/commit/98663df4))
+- defer supplemental viewer CSS ([a6e94b2](https://github.com/nteract/nteract/commit/a6e94b2e))
+- stage async output resolution ([8f32259](https://github.com/nteract/nteract/commit/8f322592))
+- lazy mount output frames ([91f3977](https://github.com/nteract/nteract/commit/91f3977d))
+- cache hosted output blobs ([5499951](https://github.com/nteract/nteract/commit/5499951d))
+- project live runtime updates incrementally ([679c6ae](https://github.com/nteract/nteract/commit/679c6ae2))
+
+### MCP, agents, and tooling
+
+- canonicalize MCP client display names ([c9f24ae](https://github.com/nteract/nteract/commit/c9f24ae3))
+- advertise generated MCP icons ([b6b6db7](https://github.com/nteract/nteract/commit/b6b6db78))
+- prefer resources for cell reads ([689034e](https://github.com/nteract/nteract/commit/689034e9))
+- expose notebook tool bridge ([497a3fa](https://github.com/nteract/nteract/commit/497a3fa7))
+- make proxy recovery messages install-aware ([c84481d](https://github.com/nteract/nteract/commit/c84481d6))
+
+</details>

--- a/lib/changelog.test.ts
+++ b/lib/changelog.test.ts
@@ -18,6 +18,7 @@ describe("changelog content utilities", () => {
     const entries = await getAllEntries(all);
 
     expect(entries.map((entry) => entry.version)).toEqual([
+      "2.7",
       "2.6",
       "2.5",
       "2.4",

--- a/lib/changelog.test.ts
+++ b/lib/changelog.test.ts
@@ -18,6 +18,7 @@ describe("changelog content utilities", () => {
     const entries = await getAllEntries(all);
 
     expect(entries.map((entry) => entry.version)).toEqual([
+      "2.6",
       "2.5",
       "2.4",
       "2.3",

--- a/lib/changelog.ts
+++ b/lib/changelog.ts
@@ -23,6 +23,8 @@ export type ChangelogFrontmatter = {
   dateLabel?: string;
   heroImage?: string;
   heroVideo?: string;
+  /** Poster still shown while heroVideo loads. */
+  heroVideoPoster?: string;
   /** Canonical GitHub release this entry points at. */
   githubReleaseUrl?: string;
   published: boolean;
@@ -114,6 +116,7 @@ function parseFrontmatter(fileName: string, data: Record<string, unknown>) {
   const dateLabel = optionalString(data.dateLabel);
   const heroImage = optionalString(data.heroImage);
   const heroVideo = optionalString(data.heroVideo);
+  const heroVideoPoster = optionalString(data.heroVideoPoster);
   const githubReleaseUrl = optionalString(data.githubReleaseUrl);
   const published =
     data.published === undefined ? true : Boolean(data.published);
@@ -129,6 +132,7 @@ function parseFrontmatter(fileName: string, data: Record<string, unknown>) {
     dateLabel,
     heroImage,
     heroVideo,
+    heroVideoPoster,
     githubReleaseUrl,
     published,
   } satisfies ChangelogFrontmatter;

--- a/next.config.ts
+++ b/next.config.ts
@@ -37,7 +37,8 @@ const withMDX = createMDX({
       [
         "rehype-pretty-code",
         {
-          theme: "github-dark",
+          theme: { light: "github-light", dark: "github-dark" },
+          defaultColor: false,
           keepBackground: false,
           defaultLang: {
             block: "text",


### PR DESCRIPTION
Finalizes the 2.6 release notes and reshapes the changelog around the actual release plan: 2.6 is the shipped desktop ergonomics release, 2.7 holds the commenting notes, and the cloud material is parked. It also wires the release-day surfaces: the custom 2.6 OG card, the homepage callout, and the 2.6.1 patch URL.

## 2.6 — shipped

2.6 is published and dated to the stable tag, [`v2.6.0-stable.202606251403`](https://github.com/nteract/nteract/releases/tag/v2.6.0-stable.202606251403). The notes cover the desktop ergonomics story (left-rail outline, package management in the rail, sturdier widget state, bare TeX as math, the Rust/WASM Markdown engine, and the notebook shell) plus the two user-feedback add-ons that landed for the release:

- Switch a cell between code and Markdown from the context and main menus (#3803, issue #3801).
- Opt out of automatic `ruff` / `deno fmt` (#3795).

The page carries a collapsed technical changelog. Every commit in it was verified against the shipped `v2.5.1 → v2.6.0` range, so the entries are real and in range, with a link out to the GitHub release for the full list. The prep scaffold and the image-capture TODO comments are gone.

## Release surfaces

- The 2.6 entry gets a custom OG card via `heroImage` (the Figma export, `2.6-og.png`), so shares of `/changelog/2.6` show the release card instead of the generated fallback. The on-page hero stays the mp4.
- The homepage "New" callout reads the latest published entry instead of a hardcoded string. It had drifted to "nteract 2.5 is out"; it now tracks the release and links straight to it.
- `coversVersions` includes `2.6.1`, so the patch URL resolves to this entry when 2.6.1 ships today.
- The changelog index keeps its handcrafted generic OG card, now commented so it is not mistaken for a stale value.

## 2.7 — commenting (draft)

`2.7.mdx` carries the commenting notes: exact-selection comments across source and rendered Markdown, content-derived quotes that re-anchor or dangle honestly, the discussion rail, and per-author identity for the people and agents in a notebook (merged in #3791, #3792, #3794, #3796, #3797, #3799). It stays `published: false` until the 2.7 release.

## Cloud — deferred

The hosted-notebook, workstation, and runtime-peer material lives in `content/changelog/_cloud-holding.mdx`. The loader skips `_`-prefixed files, so it stays drafted but unrendered.

Tests: `pnpm exec vitest run lib/changelog.test.ts` passes (8/8).
