### PR TITLE
feat: install page — desktop downloads, one-command install, headless workstations

### DIFF
--- a/app/install/page.tsx
+++ b/app/install/page.tsx
@@ -1,0 +1,174 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+import { DownloadButtons } from "@/components/home/download-buttons";
+import { Container, SiteFooter, SiteHeader } from "@/components/site-shell";
+import { siteConfig } from "@/lib/site";
+
+export const metadata: Metadata = {
+  title: "Install nteract",
+  description:
+    "Get the nteract desktop app for macOS, Windows, and Linux — or install the CLI and daemon on any Linux or macOS machine with one command, including headless workstations for hosted notebooks.",
+};
+
+async function getStableVersion(): Promise<string | null> {
+  try {
+    const res = await fetch(siteConfig.stableManifestUrl, {
+      next: { revalidate: 300 },
+    });
+    if (!res.ok) return null;
+    const manifest = (await res.json()) as { version?: string };
+    return manifest.version ?? null;
+  } catch {
+    return null;
+  }
+}
+
+const INSTALL_CMD = ["curl -fsSL https://sh.nteract.io | bash"];
+const HEADLESS_CMD = ["curl -fsSL https://sh.nteract.io | bash -s -- --headless"];
+const WORKSTATION_CMDS = [
+  "runt workstation connect https://app.runt.run --code XXXX-XXXX-XXXX",
+  "runt workstation run",
+];
+
+function CommandBlock({ commands }: { commands: string[] }) {
+  return (
+    <pre className="overflow-x-auto rounded-2xl border border-black/10 bg-slate-950 px-5 py-4 text-sm leading-7 text-slate-100 shadow-sm">
+      <code>{commands.join("\n")}</code>
+    </pre>
+  );
+}
+
+function StepCard({
+  eyebrow,
+  title,
+  children,
+}: {
+  eyebrow: string;
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="rounded-3xl border border-black/10 bg-white p-6 shadow-sm">
+      <p className="mb-3 text-xs font-semibold uppercase tracking-[0.25em] text-teal-600">
+        {eyebrow}
+      </p>
+      <h2 className="mb-4 text-2xl font-bold tracking-tight text-gray-950">
+        {title}
+      </h2>
+      <div className="space-y-4 text-[16px] leading-7 text-gray-700">{children}</div>
+    </section>
+  );
+}
+
+function InlineCode({ children }: { children: ReactNode }) {
+  return <code className="rounded bg-gray-100 px-1 py-0.5">{children}</code>;
+}
+
+export default async function InstallPage() {
+  const version = await getStableVersion();
+
+  return (
+    <div className="min-h-screen bg-gray-50 text-gray-900">
+      <SiteHeader />
+
+      <main>
+        <Container className="py-16 sm:py-24">
+          <div className="mx-auto max-w-3xl text-center">
+            <p className="mb-4 text-sm font-semibold uppercase tracking-[0.3em] text-teal-600">
+              Install
+            </p>
+            <h1 className="text-4xl font-bold tracking-tight text-gray-950 sm:text-6xl">
+              Install nteract
+            </h1>
+            <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-gray-600">
+              The desktop app for the machine in front of you. One command for
+              every other machine you own — including headless workstations
+              that run compute for hosted notebooks.
+            </p>
+          </div>
+
+          <div className="mx-auto mt-12 grid max-w-4xl gap-6">
+            <StepCard eyebrow="01" title="Desktop app">
+              <p>
+                macOS (Apple silicon or Intel), Windows, and Linux. The app
+                bundles everything: the notebook, the <InlineCode>runt</InlineCode>{" "}
+                CLI, and the <InlineCode>runtimed</InlineCode> daemon, kept up to
+                date automatically.
+              </p>
+              <DownloadButtons version={version} />
+            </StepCard>
+
+            <StepCard eyebrow="02" title="One command — Linux & macOS">
+              <CommandBlock commands={INSTALL_CMD} />
+              <p>
+                Installs the app plus <InlineCode>runt</InlineCode>,{" "}
+                <InlineCode>runtimed</InlineCode>, and{" "}
+                <InlineCode>nteract-mcp</InlineCode>, links the commands into{" "}
+                <InlineCode>~/.local/bin</InlineCode>, and sets up the per-user
+                daemon service (systemd on Linux, launchd on macOS). Everything
+                is per-user — no root, no system package manager. Re-run the
+                same command to upgrade.
+              </p>
+            </StepCard>
+
+            <StepCard eyebrow="03" title="Headless servers & remote workstations">
+              <p>
+                For machines that only run compute — an Outerbounds workstation,
+                a JupyterHub single-user server, a beefy box under your desk —
+                skip the desktop app:
+              </p>
+              <CommandBlock commands={HEADLESS_CMD} />
+              <p>
+                To offer that machine&rsquo;s compute to a hosted notebook, open
+                the notebook&rsquo;s workstation panel, choose{" "}
+                <strong className="text-gray-950">Add workstation</strong> to
+                mint a pairing code, and run the two commands it shows you:
+              </p>
+              <CommandBlock commands={WORKSTATION_CMDS} />
+              <p>
+                The machine appears in the panel by name and serves execution
+                over an outbound connection — no inbound ports, no reverse
+                proxy. Workstation pairing ships with the next stable release
+                and is available on{" "}
+                <Link
+                  href="/nightly"
+                  className="font-medium text-teal-700 underline decoration-teal-700/30 underline-offset-4 hover:text-teal-900"
+                >
+                  nightly
+                </Link>{" "}
+                today.
+              </p>
+            </StepCard>
+
+            <StepCard eyebrow="04" title="Channels">
+              <p>
+                Stable is the default everywhere above. The{" "}
+                <Link
+                  href="/nightly"
+                  className="font-medium text-teal-700 underline decoration-teal-700/30 underline-offset-4 hover:text-teal-900"
+                >
+                  nightly channel
+                </Link>{" "}
+                installs side-by-side with channel-suffixed commands
+                (<InlineCode>runt-nightly</InlineCode>,{" "}
+                <InlineCode>nteract-nightly</InlineCode>), so you can run both.
+                Agents have their own setup — see{" "}
+                <Link
+                  href="/agents"
+                  className="font-medium text-teal-700 underline decoration-teal-700/30 underline-offset-4 hover:text-teal-900"
+                >
+                  nteract for agents
+                </Link>
+                .
+              </p>
+            </StepCard>
+          </div>
+        </Container>
+      </main>
+
+      <SiteFooter />
+    </div>
+  );
+}

--- a/app/install/page.tsx
+++ b/app/install/page.tsx
@@ -103,13 +103,14 @@ export default async function InstallPage() {
             <StepCard eyebrow="02" title="One command — Linux & macOS">
               <CommandBlock commands={INSTALL_CMD} />
               <p>
-                Installs the app plus <InlineCode>runt</InlineCode>,{" "}
-                <InlineCode>runtimed</InlineCode>, and{" "}
-                <InlineCode>nteract-mcp</InlineCode>, links the commands into{" "}
-                <InlineCode>~/.local/bin</InlineCode>, and sets up the per-user
-                daemon service (systemd on Linux, launchd on macOS). Everything
-                is per-user — no root, no system package manager. Re-run the
-                same command to upgrade.
+                Installs the app (the AppImage on Linux; the signed bundle in{" "}
+                <InlineCode>~/Applications</InlineCode> on macOS) plus{" "}
+                <InlineCode>runt</InlineCode>, <InlineCode>runtimed</InlineCode>,
+                and <InlineCode>nteract-mcp</InlineCode>, links the commands
+                into <InlineCode>~/.local/bin</InlineCode>, and sets up the
+                per-user daemon service (systemd on Linux, launchd on macOS).
+                Everything is per-user — no root, no system package manager.
+                Re-run the same command to upgrade.
               </p>
             </StepCard>
 
@@ -130,15 +131,15 @@ export default async function InstallPage() {
               <p>
                 The machine appears in the panel by name and serves execution
                 over an outbound connection — no inbound ports, no reverse
-                proxy. Workstation pairing ships with the next stable release
-                and is available on{" "}
+                proxy. Workstation pairing ships with the next stable release;
+                the{" "}
                 <Link
                   href="/nightly"
                   className="font-medium text-teal-700 underline decoration-teal-700/30 underline-offset-4 hover:text-teal-900"
                 >
-                  nightly
+                  nightly channel
                 </Link>{" "}
-                today.
+                has it first.
               </p>
             </StepCard>
 

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -14,6 +14,11 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 1,
     },
     {
+      url: absoluteUrl("/install"),
+      changeFrequency: "monthly",
+      priority: 0.9,
+    },
+    {
       url: absoluteUrl("/agents"),
       changeFrequency: "monthly",
       priority: 0.7,

--- a/components/site-shell.tsx
+++ b/components/site-shell.tsx
@@ -18,6 +18,7 @@ export function Container({ className, ...props }: ContainerProps) {
 }
 
 const navLinks = [
+  { href: "/install", label: "Install" },
   { href: "/agents", label: "Agents" },
   { href: "/changelog", label: "Changelog" },
   { href: "/blog", label: "Blog" },

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
Adds **/install** to the site (nav + sitemap included), covering the three install shapes:

1. **Desktop app** — reuses the landing page's platform-detected `DownloadButtons` (macOS arm64/Intel DMG, Windows exe, Linux AppImage) with the stable-manifest version.
2. **One command (Linux & macOS)** — the `sh.nteract.io` one-liner. **This works on macOS today**: nteract/nteract#3612 (darwin-aware installer) and nteract/install-sh#1 (bootstrap gate + bridge) are both merged, and the deployed `sh.nteract.io` already serves the darwin-aware bootstrap (verified live). Copy names the per-user layout: app in `~/Applications` on macOS, commands in `~/.local/bin`, systemd/launchd service, re-run to upgrade.
3. **Headless servers & remote workstations** — `--headless` plus the `runt workstation connect / run` pairing flow (nteract/nteract#3611, merged) — framed as *next stable; nightly channel has it first*.

Structure follows the agents page idiom (SiteHeader/Footer, StepCard, CommandBlock). `pnpm build` renders `/install` and all 64 site tests pass.

One deliberately-left-alone follow-up: the landing page's macOS primary stays the DMG (drag-install is the familiar path); the one-liner lives here. Happy to add it as a secondary on the landing page in a follow-up if you'd rather surface it there too.