### PR TITLE
refactor: coalesce product pages on shared primitives, bring home into the shell

### DIFF
--- a/app/agents/page.tsx
+++ b/app/agents/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import type { ReactNode } from "react";
 
+import { CommandBlock, InlineCode, PageHero, StepCard } from "@/components/product/page-primitives";
 import { Container, SiteFooter, SiteHeader } from "@/components/site-shell";
 
 export const metadata: Metadata = {
@@ -21,36 +21,6 @@ const codexCommands = [
   "# Then run /plugin in Codex and enable nteract or nightly",
 ];
 
-function CommandBlock({ commands }: { commands: string[] }) {
-  return (
-    <pre className="overflow-x-auto rounded-2xl border border-black/10 bg-slate-950 px-5 py-4 text-sm leading-7 text-slate-100 shadow-sm">
-      <code>{commands.join("\n")}</code>
-    </pre>
-  );
-}
-
-function StepCard({
-  eyebrow,
-  title,
-  children,
-}: {
-  eyebrow: string;
-  title: string;
-  children: ReactNode;
-}) {
-  return (
-    <section className="rounded-3xl border border-black/10 bg-white p-6 shadow-sm">
-      <p className="mb-3 text-xs font-semibold uppercase tracking-[0.25em] text-teal-600">
-        {eyebrow}
-      </p>
-      <h2 className="mb-4 text-2xl font-bold tracking-tight text-gray-950">
-        {title}
-      </h2>
-      <div className="space-y-4 text-[16px] leading-7 text-gray-700">{children}</div>
-    </section>
-  );
-}
-
 export default function AgentsPage() {
   return (
     <div className="min-h-screen bg-gray-50 text-gray-900">
@@ -58,20 +28,18 @@ export default function AgentsPage() {
 
       <main>
         <Container className="py-16 sm:py-24">
-          <div className="mx-auto max-w-3xl text-center">
-            <p className="mb-4 text-sm font-semibold uppercase tracking-[0.3em] text-teal-600">
-              Agents
-            </p>
-            <h1 className="text-4xl font-bold tracking-tight text-gray-950 sm:text-6xl">
-              Use nteract as your agent notebook
-            </h1>
-            <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-gray-600">
-              nteract plugins let Claude Code and Codex run exploratory Python in
-              a live notebook instead of hiding work in one-off shell commands.
-              The notebook keeps state, captures rich outputs, and stays available
-              for humans to inspect, edit, and save.
-            </p>
-          </div>
+          <PageHero
+            eyebrow="Agents"
+            title="Use nteract as your agent notebook"
+            subtitle={
+              <>
+                nteract plugins let Claude Code and Codex run exploratory Python in
+                a live notebook instead of hiding work in one-off shell commands.
+                The notebook keeps state, captures rich outputs, and stays available
+                for humans to inspect, edit, and save.
+              </>
+            }
+          />
 
           <div className="mx-auto mt-12 grid max-w-4xl gap-6">
             <StepCard eyebrow="01" title="Choose the stable or nightly plugin">
@@ -104,7 +72,7 @@ export default function AgentsPage() {
               <CommandBlock commands={claudeCommands} />
               <p>
                 Claude Code pins plugins at install time. To install a known
-                release, add <code className="rounded bg-gray-100 px-1 py-0.5">--ref vX.Y.Z</code>{" "}
+                release, add <InlineCode>--ref vX.Y.Z</InlineCode>{" "}
                 to the install command.
               </p>
             </StepCard>
@@ -113,7 +81,7 @@ export default function AgentsPage() {
               <CommandBlock commands={codexCommands} />
               <p>
                 After registering the marketplace, start or restart Codex, run{" "}
-                <code className="rounded bg-gray-100 px-1 py-0.5">/plugin</code>,
+                <InlineCode>/plugin</InlineCode>,
                 pick the nteract marketplace, and enable the stable or nightly
                 plugin. Codex resolves the platform-specific sidecar bundled with
                 the plugin.
@@ -146,8 +114,8 @@ export default function AgentsPage() {
                 </li>
                 <li>
                   If the agent reports runtime issues, open nteract locally and run{" "}
-                  <code className="rounded bg-gray-100 px-1 py-0.5">runt doctor</code>{" "}
-                  or <code className="rounded bg-gray-100 px-1 py-0.5">runt-nightly doctor</code>.
+                  <InlineCode>runt doctor</InlineCode>{" "}
+                  or <InlineCode>runt-nightly doctor</InlineCode>.
                 </li>
               </ul>
             </StepCard>

--- a/app/install/page.tsx
+++ b/app/install/page.tsx
@@ -9,7 +9,7 @@ import { siteConfig } from "@/lib/site";
 export const metadata: Metadata = {
   title: "Install nteract",
   description:
-    "Get the nteract desktop app for macOS, Windows, and Linux — or install the CLI and daemon on any Linux or macOS machine with one command, including headless workstations for hosted notebooks.",
+    "Get the nteract desktop app for macOS, Windows, and Linux — or install the CLI and daemon on any Linux or macOS machine with one command.",
 };
 
 async function getStableVersion(): Promise<string | null> {
@@ -26,11 +26,6 @@ async function getStableVersion(): Promise<string | null> {
 }
 
 const INSTALL_CMD = ["curl -fsSL https://sh.nteract.io | bash"];
-const HEADLESS_CMD = ["curl -fsSL https://sh.nteract.io | bash -s -- --headless"];
-const WORKSTATION_CMDS = [
-  "runt workstation connect https://app.runt.run --code XXXX-XXXX-XXXX",
-  "runt workstation run",
-];
 
 export default async function InstallPage() {
   const version = await getStableVersion();
@@ -47,8 +42,7 @@ export default async function InstallPage() {
             subtitle={
               <>
                 The desktop app for the machine in front of you. One command for
-                every other machine you own — including headless workstations
-                that run compute for hosted notebooks.
+                every other machine you own.
               </>
             }
           />
@@ -78,36 +72,7 @@ export default async function InstallPage() {
               </p>
             </StepCard>
 
-            <StepCard eyebrow="03" title="Headless servers & remote workstations">
-              <p>
-                For machines that only run compute — an Outerbounds workstation,
-                a JupyterHub single-user server, a beefy box under your desk —
-                skip the desktop app:
-              </p>
-              <CommandBlock commands={HEADLESS_CMD} />
-              <p>
-                To offer that machine&rsquo;s compute to a hosted notebook, open
-                the notebook&rsquo;s workstation panel, choose{" "}
-                <strong className="text-gray-950">Add workstation</strong> to
-                mint a pairing code, and run the two commands it shows you:
-              </p>
-              <CommandBlock commands={WORKSTATION_CMDS} />
-              <p>
-                The machine appears in the panel by name and serves execution
-                over an outbound connection — no inbound ports, no reverse
-                proxy. Workstation pairing ships with the next stable release;
-                the{" "}
-                <Link
-                  href="/nightly"
-                  className="font-medium text-teal-700 underline decoration-teal-700/30 underline-offset-4 hover:text-teal-900"
-                >
-                  nightly channel
-                </Link>{" "}
-                has it first.
-              </p>
-            </StepCard>
-
-            <StepCard eyebrow="04" title="Channels">
+            <StepCard eyebrow="03" title="Channels">
               <p>
                 Stable is the default everywhere above. The{" "}
                 <Link

--- a/app/install/page.tsx
+++ b/app/install/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import type { ReactNode } from "react";
 
 import { DownloadButtons } from "@/components/home/download-buttons";
+import { CommandBlock, InlineCode, PageHero, StepCard } from "@/components/product/page-primitives";
 import { Container, SiteFooter, SiteHeader } from "@/components/site-shell";
 import { siteConfig } from "@/lib/site";
 
@@ -32,40 +32,6 @@ const WORKSTATION_CMDS = [
   "runt workstation run",
 ];
 
-function CommandBlock({ commands }: { commands: string[] }) {
-  return (
-    <pre className="overflow-x-auto rounded-2xl border border-black/10 bg-slate-950 px-5 py-4 text-sm leading-7 text-slate-100 shadow-sm">
-      <code>{commands.join("\n")}</code>
-    </pre>
-  );
-}
-
-function StepCard({
-  eyebrow,
-  title,
-  children,
-}: {
-  eyebrow: string;
-  title: string;
-  children: ReactNode;
-}) {
-  return (
-    <section className="rounded-3xl border border-black/10 bg-white p-6 shadow-sm">
-      <p className="mb-3 text-xs font-semibold uppercase tracking-[0.25em] text-teal-600">
-        {eyebrow}
-      </p>
-      <h2 className="mb-4 text-2xl font-bold tracking-tight text-gray-950">
-        {title}
-      </h2>
-      <div className="space-y-4 text-[16px] leading-7 text-gray-700">{children}</div>
-    </section>
-  );
-}
-
-function InlineCode({ children }: { children: ReactNode }) {
-  return <code className="rounded bg-gray-100 px-1 py-0.5">{children}</code>;
-}
-
 export default async function InstallPage() {
   const version = await getStableVersion();
 
@@ -75,19 +41,17 @@ export default async function InstallPage() {
 
       <main>
         <Container className="py-16 sm:py-24">
-          <div className="mx-auto max-w-3xl text-center">
-            <p className="mb-4 text-sm font-semibold uppercase tracking-[0.3em] text-teal-600">
-              Install
-            </p>
-            <h1 className="text-4xl font-bold tracking-tight text-gray-950 sm:text-6xl">
-              Install nteract
-            </h1>
-            <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-gray-600">
-              The desktop app for the machine in front of you. One command for
-              every other machine you own — including headless workstations
-              that run compute for hosted notebooks.
-            </p>
-          </div>
+          <PageHero
+            eyebrow="Install"
+            title="Install nteract"
+            subtitle={
+              <>
+                The desktop app for the machine in front of you. One command for
+                every other machine you own — including headless workstations
+                that run compute for hosted notebooks.
+              </>
+            }
+          />
 
           <div className="mx-auto mt-12 grid max-w-4xl gap-6">
             <StepCard eyebrow="01" title="Desktop app">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -23,7 +23,7 @@ export default async function Home() {
 
   return (
     <div className="flex min-h-screen flex-col">
-      <SiteHeader />
+      <SiteHeader variant="floating" />
       <main className="flex flex-1 flex-col items-center justify-center px-4 py-16">
         <div className="max-w-2xl mx-auto text-center">
           <Link

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 
 import { Logo } from "@/components/logo";
 import { DownloadButtons } from "@/components/home/download-buttons";
+import { SiteFooter, SiteHeader } from "@/components/site-shell";
 import { siteConfig } from "@/lib/site";
 
 async function getStableVersion(): Promise<string | null> {
@@ -21,77 +22,57 @@ export default async function Home() {
   const version = await getStableVersion();
 
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center px-4 py-16">
-      <div className="max-w-2xl mx-auto text-center">
-        <Link
-          href="/changelog"
-          className="group mb-10 inline-flex items-center gap-2 rounded-full border border-gray-200 bg-white py-1 pl-1.5 pr-4 text-sm shadow-sm transition hover:border-gray-300 hover:shadow"
-        >
-          <span className="rounded-full bg-accent px-2.5 py-0.5 text-xs font-semibold text-white">
-            New
-          </span>
-          <span className="font-medium text-gray-700 transition-colors group-hover:text-gray-900">
-            nteract 2.5 is out
-          </span>
-          <span className="text-gray-400 transition-transform group-hover:translate-x-0.5">
-            →
-          </span>
-        </Link>
-
-        <Logo className="w-40 h-40 mx-auto mb-8" />
-
-        <p className="text-sm uppercase tracking-widest text-gray-400 mb-2">
-          Native interactive notebooks
-        </p>
-        <h1 className="text-5xl font-bold text-gray-900 mb-3">
-          {siteConfig.name}
-        </h1>
-        <p className="text-base text-gray-500 mb-8 max-w-md mx-auto">
-          Fast to launch. Agent ready. Humans welcome.
-        </p>
-
-        <DownloadButtons version={version} />
-
-        <div className="mt-12">
+    <div className="flex min-h-screen flex-col">
+      <SiteHeader />
+      <main className="flex flex-1 flex-col items-center justify-center px-4 py-16">
+        <div className="max-w-2xl mx-auto text-center">
           <Link
-            href="/agents"
-            className="group inline-flex items-center gap-2 text-sm text-gray-500 transition-colors hover:text-gray-900"
+            href="/changelog"
+            className="group mb-10 inline-flex items-center gap-2 rounded-full border border-gray-200 bg-white py-1 pl-1.5 pr-4 text-sm shadow-sm transition hover:border-gray-300 hover:shadow"
           >
-            <span className="text-base">🤖</span>
-            <span>
-              <span className="font-medium text-gray-700 group-hover:text-gray-900">
-                Using agents?
-              </span>{" "}
-              Install the plugins
+            <span className="rounded-full bg-accent px-2.5 py-0.5 text-xs font-semibold text-white">
+              New
             </span>
-            <span className="transition-transform group-hover:translate-x-0.5">→</span>
+            <span className="font-medium text-gray-700 transition-colors group-hover:text-gray-900">
+              nteract 2.5 is out
+            </span>
+            <span className="text-gray-400 transition-transform group-hover:translate-x-0.5">
+              →
+            </span>
           </Link>
-        </div>
 
-      </div>
+          <Logo className="w-40 h-40 mx-auto mb-8" />
 
-      <footer className="mt-24 pb-8 text-center">
-        <div className="flex items-center justify-center gap-6 text-sm text-gray-400 mb-8">
-          <Link
-            href="/blog"
-            className="hover:text-gray-600 transition-colors"
-          >
-            Blog
-          </Link>
-          <a
-            href={siteConfig.links.github}
-            className="hover:text-gray-600 transition-colors"
-            rel="noreferrer"
-            target="_blank"
-          >
-            GitHub
-          </a>
+          <p className="text-sm uppercase tracking-widest text-gray-400 mb-2">
+            Native interactive notebooks
+          </p>
+          <h1 className="text-5xl font-bold text-gray-900 mb-3">
+            {siteConfig.name}
+          </h1>
+          <p className="text-base text-gray-500 mb-8 max-w-md mx-auto">
+            Fast to launch. Agent ready. Humans welcome.
+          </p>
+
+          <DownloadButtons version={version} />
+
+          <div className="mt-12">
+            <Link
+              href="/agents"
+              className="group inline-flex items-center gap-2 text-sm text-gray-500 transition-colors hover:text-gray-900"
+            >
+              <span className="text-base">🤖</span>
+              <span>
+                <span className="font-medium text-gray-700 group-hover:text-gray-900">
+                  Using agents?
+                </span>{" "}
+                Install the plugins
+              </span>
+              <span className="transition-transform group-hover:translate-x-0.5">→</span>
+            </Link>
+          </div>
         </div>
-        <p className="text-sm text-gray-400 italic max-w-md mx-auto">
-          "The purpose of computing is insight, not numbers."
-        </p>
-        <p className="text-xs text-gray-400 mt-1">— Richard Hamming</p>
-      </footer>
-    </main>
+      </main>
+      <SiteFooter />
+    </div>
   );
 }

--- a/components/product/page-primitives.tsx
+++ b/components/product/page-primitives.tsx
@@ -1,0 +1,102 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * Eyebrow label for product pages (install, agents, docs). One convention
+ * so the product pages stop drifting between tracking-widest, tracking-[0.25em],
+ * and tracking-[0.3em]. Uses teal-600 as the text accent (readable on the
+ * bg-gray-50 product surface); the --accent token stays for fills.
+ */
+export function ProductEyebrow({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <p
+      className={cn(
+        "text-sm font-semibold uppercase tracking-[0.3em] text-teal-600",
+        className,
+      )}
+    >
+      {children}
+    </p>
+  );
+}
+
+/**
+ * Centered hero block for product pages: eyebrow + h1 + subtitle. Install
+ * and agents share this exact shape; home can adopt it too.
+ */
+export function PageHero({
+  eyebrow,
+  title,
+  subtitle,
+}: {
+  eyebrow: string;
+  title: ReactNode;
+  subtitle: ReactNode;
+}) {
+  return (
+    <div className="mx-auto max-w-3xl text-center">
+      <ProductEyebrow className="mb-4">{eyebrow}</ProductEyebrow>
+      <h1 className="text-4xl font-bold tracking-tight text-gray-950 sm:text-6xl">
+        {title}
+      </h1>
+      <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-gray-600">
+        {subtitle}
+      </p>
+    </div>
+  );
+}
+
+/**
+ * Numbered step card for install/agents flows: eyebrow (usually "01", "02"...)
+ * + title + body. The rounded-3xl white card on the gray-50 product surface.
+ */
+export function StepCard({
+  eyebrow,
+  title,
+  children,
+}: {
+  eyebrow: string;
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="rounded-3xl border border-black/10 bg-white p-6 shadow-sm">
+      <p className="mb-3 text-xs font-semibold uppercase tracking-[0.25em] text-teal-600">
+        {eyebrow}
+      </p>
+      <h2 className="mb-4 text-2xl font-bold tracking-tight text-gray-950">
+        {title}
+      </h2>
+      <div className="space-y-4 text-[16px] leading-7 text-gray-700">
+        {children}
+      </div>
+    </section>
+  );
+}
+
+/**
+ * Dark command block for shell commands. Slate-950 bg, slate-100 text.
+ */
+export function CommandBlock({ commands }: { commands: string[] }) {
+  return (
+    <pre className="overflow-x-auto rounded-2xl border border-black/10 bg-slate-950 px-5 py-4 text-sm leading-7 text-slate-100 shadow-sm">
+      <code>{commands.join("\n")}</code>
+    </pre>
+  );
+}
+
+/**
+ * Inline code chip for command names and file paths in body copy.
+ */
+export function InlineCode({ children }: { children: ReactNode }) {
+  return (
+    <code className="rounded bg-gray-100 px-1 py-0.5">{children}</code>
+  );
+}

--- a/components/site-shell.tsx
+++ b/components/site-shell.tsx
@@ -6,7 +6,7 @@ import { siteConfig } from "@/lib/site";
 import { cn } from "@/lib/utils";
 
 type ContainerProps = HTMLAttributes<HTMLDivElement>;
-type HeaderVariant = "light" | "dark";
+type HeaderVariant = "light" | "dark" | "floating";
 
 export function Container({ className, ...props }: ContainerProps) {
   return (
@@ -71,6 +71,30 @@ interface SiteHeaderProps {
 
 export function SiteHeader({ variant = "light" }: SiteHeaderProps) {
   const isDark = variant === "dark";
+  const isFloating = variant === "floating";
+
+  if (isFloating) {
+    return (
+      <header className="sticky top-0 z-50 px-4 pt-4 sm:pt-6">
+        <div className="mx-auto flex max-w-3xl items-center justify-between gap-4 rounded-full border border-black/5 bg-white/80 px-4 py-2.5 shadow-sm backdrop-blur-md sm:px-6">
+          <Link
+            href="/"
+            className="inline-flex items-center gap-2.5 transition-opacity hover:opacity-80"
+          >
+            <Logo className="h-7 w-7" />
+            <span className="text-sm font-semibold tracking-tight text-gray-900">
+              {siteConfig.name}
+            </span>
+          </Link>
+          <nav className="flex items-center gap-3 sm:gap-5">
+            {navLinks.map((link) => (
+              <SiteNavLink key={link.href} {...link} />
+            ))}
+          </nav>
+        </div>
+      </header>
+    );
+  }
 
   return (
     <header


### PR DESCRIPTION
## Overview

Coalesces the product pages (install, agents, home) onto shared primitives and brings home into the site shell. Install and agents were duplicating `CommandBlock`, `StepCard`, `InlineCode`, and the hero pattern between two files. Home was the outlier with no `SiteHeader` or `SiteFooter`, so a visitor landing on `/` had no nav to reach install, agents, changelog, or blog.

## What changed

**New `components/product/page-primitives.tsx`** - one set of primitives for the product pages:
- `ProductEyebrow` - one uppercase label convention (`tracking-[0.3em]`, `teal-600`), killing the `tracking-widest` / `[0.25em]` / `[0.3em]` split across pages.
- `PageHero` - centered eyebrow + h1 + subtitle, shared by install and agents.
- `StepCard` - the rounded-3xl white card with numbered eyebrow.
- `CommandBlock` - the slate-950 shell command block.
- `InlineCode` - the gray-100 inline code chip.

**Home** - wrapped in `SiteHeader` + `SiteFooter`, dropped the duplicated inline footer (`SiteFooter` already carries the Hamming quote and full nav). The centered hero stays.

**Install + agents** - swapped local copies for the shared primitives, replaced inline `<code>` chips with `<InlineCode>`. Net -87 lines across the three files.

## What stays as-is

The three deliberate page voices are preserved:
- **Product pages** (install, agents, now home too): light, teal, step cards, in the site shell.
- **Editorial cream** (changelog, telemetry): the desktop app's cream palette, long-form reading.
- **Blog dark**: the tech dev log, dark surface, purple accent.

The coalescing is within the product-page voice, not across voices.

## Test plan

- [x] `next build` - all 25 pages compile and prerender
- [x] `tsc --noEmit` - typecheck clean
- [x] `vitest run` - 64 tests pass across 7 files
- [ ] Visual QA: confirm home renders with header/footer nav, install and agents render identically to before (the primitives produce the same markup)
