### PR TITLE
Add blog post author attribution

### DIFF
--- a/app/(blog)/blog/[slug]/llms.txt/route.ts
+++ b/app/(blog)/blog/[slug]/llms.txt/route.ts
@@ -1,5 +1,7 @@
 import { renderPlaceholder } from "fumadocs-core/mdx-plugins/remark-llms.runtime";
+import matter from "gray-matter";
 
+import { formatAuthorNames, formatNameList } from "@/lib/authors";
 import { getAllSlugs, getPostBySlug } from "@/lib/blog";
 import { resolveBlogPlaceholders } from "@/lib/blog-md";
 
@@ -26,10 +28,24 @@ export async function GET(_request: Request, { params }: RouteContext) {
   }
 
   const { _markdown } = await import(`@/content/blog/${slug}.mdx`);
+  const { content } = matter(_markdown);
 
-  const md = await renderPlaceholder(_markdown, resolveBlogPlaceholders);
+  const md = await renderPlaceholder(content, resolveBlogPlaceholders);
+  const header = [
+    `# ${post.title}`,
+    "",
+    `Description: ${post.description}`,
+    `Date: ${post.date}`,
+    ...(post.authors.length > 0
+      ? [`Author: ${formatAuthorNames(post.authors)}`]
+      : []),
+    ...(post.editors.length > 0
+      ? [`Edited with ${formatNameList(post.editors)}`]
+      : []),
+    "",
+  ].join("\n");
 
-  return new Response(md, {
+  return new Response(`${header}\n${md.trimStart()}`, {
     headers: {
       "Content-Type": "text/plain; charset=utf-8",
       "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400",

--- a/app/(blog)/blog/[slug]/llms.txt/route.ts
+++ b/app/(blog)/blog/[slug]/llms.txt/route.ts
@@ -1,7 +1,7 @@
 import { renderPlaceholder } from "fumadocs-core/mdx-plugins/remark-llms.runtime";
 import matter from "gray-matter";
 
-import { formatAuthorNames, formatNameList } from "@/lib/authors";
+import { formatAuthorNames } from "@/lib/authors";
 import { getAllSlugs, getPostBySlug } from "@/lib/blog";
 import { resolveBlogPlaceholders } from "@/lib/blog-md";
 
@@ -38,9 +38,6 @@ export async function GET(_request: Request, { params }: RouteContext) {
     `Date: ${post.date}`,
     ...(post.authors.length > 0
       ? [`Author: ${formatAuthorNames(post.authors)}`]
-      : []),
-    ...(post.editors.length > 0
-      ? [`Edited with ${formatNameList(post.editors)}`]
       : []),
     "",
   ].join("\n");

--- a/app/(blog)/blog/[slug]/page.tsx
+++ b/app/(blog)/blog/[slug]/page.tsx
@@ -2,8 +2,10 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
+import { BlogAuthorByline } from "@/components/blog/author-byline";
 import { BlogTagList } from "@/components/blog/tag-list";
 import { Prose } from "@/components/prose";
+import { formatAuthorNames, formatNameList } from "@/lib/authors";
 import { formatPostDate, getAllSlugs, getPostBySlug } from "@/lib/blog";
 import { absoluteUrl } from "@/lib/site";
 
@@ -33,10 +35,17 @@ export async function generateMetadata({
   }
 
   const canonical = absoluteUrl(`/blog/${post.slug}`);
+  const authorNames = formatAuthorNames(post.authors);
+  const authors = post.authors.map((author) => ({
+    name: author.name,
+    url: author.url,
+  }));
 
   return {
     title: post.title,
     description: post.description,
+    authors: authors.length > 0 ? authors : undefined,
+    creator: authorNames || undefined,
     alternates: {
       canonical,
     },
@@ -46,6 +55,9 @@ export async function generateMetadata({
       url: canonical,
       type: "article",
       publishedTime: post.date,
+      authors: authorNames
+        ? post.authors.map((author) => author.name)
+        : undefined,
       tags: post.tags,
       images: [post.ogImage ?? absoluteUrl("/opengraph-image")],
     },
@@ -67,6 +79,7 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
   }
 
   const { default: Content } = await import(`@/content/blog/${slug}.mdx`);
+  const editorNames = formatNameList(post.editors);
 
   return (
     <div className="px-6 pb-24 pt-12 md:px-12">
@@ -87,6 +100,12 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
             >
               {formatPostDate(post.date)}
             </time>
+            {post.authors.length > 0 ? (
+              <>
+                <div className="h-px w-4 bg-outline-variant/20" />
+                <BlogAuthorByline authors={post.authors} />
+              </>
+            ) : null}
           </div>
 
           <h1 className="mb-6 font-headline text-6xl font-bold leading-[0.9] tracking-tighter text-on-surface md:text-8xl">
@@ -120,6 +139,11 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
 
           <div className="flex flex-wrap items-center gap-6">
             <BlogTagList tags={post.tags} />
+            {editorNames ? (
+              <span className="text-sm text-on-surface-variant">
+                Edited with {editorNames}
+              </span>
+            ) : null}
           </div>
         </header>
 

--- a/app/(blog)/blog/[slug]/page.tsx
+++ b/app/(blog)/blog/[slug]/page.tsx
@@ -5,7 +5,7 @@ import { notFound } from "next/navigation";
 import { BlogAuthorByline } from "@/components/blog/author-byline";
 import { BlogTagList } from "@/components/blog/tag-list";
 import { Prose } from "@/components/prose";
-import { formatAuthorNames, formatNameList } from "@/lib/authors";
+import { formatAuthorNames } from "@/lib/authors";
 import { formatPostDate, getAllSlugs, getPostBySlug } from "@/lib/blog";
 import { absoluteUrl } from "@/lib/site";
 
@@ -79,7 +79,6 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
   }
 
   const { default: Content } = await import(`@/content/blog/${slug}.mdx`);
-  const editorNames = formatNameList(post.editors);
 
   return (
     <div className="px-6 pb-24 pt-12 md:px-12">
@@ -139,11 +138,6 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
 
           <div className="flex flex-wrap items-center gap-6">
             <BlogTagList tags={post.tags} />
-            {editorNames ? (
-              <span className="text-sm text-on-surface-variant">
-                Edited with {editorNames}
-              </span>
-            ) : null}
           </div>
         </header>
 

--- a/app/(blog)/blog/page.test.tsx
+++ b/app/(blog)/blog/page.test.tsx
@@ -25,7 +25,6 @@ describe("BlogPage", () => {
         published: true,
         tags: ["MDX"],
         authors: [],
-        editors: [],
       },
     ]);
 

--- a/app/(blog)/blog/page.test.tsx
+++ b/app/(blog)/blog/page.test.tsx
@@ -24,6 +24,8 @@ describe("BlogPage", () => {
         date: "2026-03-10",
         published: true,
         tags: ["MDX"],
+        authors: [],
+        editors: [],
       },
     ]);
 

--- a/app/(blog)/blog/page.tsx
+++ b/app/(blog)/blog/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 
+import { BlogAuthorByline } from "@/components/blog/author-byline";
 import { BlogPostCard } from "@/components/blog/post-card";
 import { BlogTagList } from "@/components/blog/tag-list";
 import { formatPostDate, getAllPosts } from "@/lib/blog";
@@ -52,6 +53,12 @@ export default async function BlogPage() {
               >
                 {formatPostDate(latest.date)}
               </time>
+              {latest.authors.length > 0 ? (
+                <>
+                  <div className="h-px w-4 bg-outline-variant/20" />
+                  <BlogAuthorByline authors={latest.authors} />
+                </>
+              ) : null}
               <div className="h-px w-4 bg-outline-variant/20" />
               <a
                 href={siteConfig.links.rss}

--- a/app/feed.xml/route.ts
+++ b/app/feed.xml/route.ts
@@ -16,20 +16,35 @@ export async function GET() {
   const posts = await getAllPosts();
 
   const items = posts
-    .map(
-      (post) => `
+    .map((post) => {
+      const creators = post.authors
+        .map(
+          (author) => `
+          <dc:creator>${escapeXml(author.name)}</dc:creator>`,
+        )
+        .join("");
+      const contributors = post.editors
+        .map(
+          (editor) => `
+          <dc:contributor>${escapeXml(editor)}</dc:contributor>`,
+        )
+        .join("");
+
+      return `
         <item>
           <title>${escapeXml(post.title)}</title>
           <description>${escapeXml(post.description)}</description>
           <link>${absoluteUrl(`/blog/${post.slug}`)}</link>
           <guid>${absoluteUrl(`/blog/${post.slug}`)}</guid>
           <pubDate>${new Date(post.date).toUTCString()}</pubDate>
-        </item>`
-    )
+          ${creators}
+          ${contributors}
+        </item>`;
+    })
     .join("");
 
   const rss = `<?xml version="1.0" encoding="UTF-8"?>
-    <rss version="2.0">
+    <rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/">
       <channel>
         <title>${escapeXml(`${siteConfig.name} Blog`)}</title>
         <description>${escapeXml(siteConfig.blogDescription)}</description>

--- a/app/feed.xml/route.ts
+++ b/app/feed.xml/route.ts
@@ -23,12 +23,6 @@ export async function GET() {
           <dc:creator>${escapeXml(author.name)}</dc:creator>`,
         )
         .join("");
-      const contributors = post.editors
-        .map(
-          (editor) => `
-          <dc:contributor>${escapeXml(editor)}</dc:contributor>`,
-        )
-        .join("");
 
       return `
         <item>
@@ -38,7 +32,6 @@ export async function GET() {
           <guid>${absoluteUrl(`/blog/${post.slug}`)}</guid>
           <pubDate>${new Date(post.date).toUTCString()}</pubDate>
           ${creators}
-          ${contributors}
         </item>`;
     })
     .join("");

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -1,23 +1,13 @@
-import { formatAuthorNames, formatNameList } from "@/lib/authors";
+import { formatAuthorNames } from "@/lib/authors";
 import { getAllPosts, type BlogPostSummary } from "@/lib/blog";
 import { absoluteUrl, siteConfig } from "@/lib/site";
 
 export const revalidate = 300;
 
 function attributionForPost(post: BlogPostSummary) {
-  const parts = [];
   const authorNames = formatAuthorNames(post.authors);
-  const editorNames = formatNameList(post.editors);
 
-  if (authorNames) {
-    parts.push(`Author: ${authorNames}`);
-  }
-
-  if (editorNames) {
-    parts.push(`Edited with ${editorNames}`);
-  }
-
-  return parts.length > 0 ? ` ${parts.join(". ")}.` : "";
+  return authorNames ? ` Author: ${authorNames}.` : "";
 }
 
 async function getStableVersion(): Promise<string | null> {

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -1,7 +1,24 @@
-import { getAllPosts } from "@/lib/blog";
+import { formatAuthorNames, formatNameList } from "@/lib/authors";
+import { getAllPosts, type BlogPostSummary } from "@/lib/blog";
 import { absoluteUrl, siteConfig } from "@/lib/site";
 
 export const revalidate = 300;
+
+function attributionForPost(post: BlogPostSummary) {
+  const parts = [];
+  const authorNames = formatAuthorNames(post.authors);
+  const editorNames = formatNameList(post.editors);
+
+  if (authorNames) {
+    parts.push(`Author: ${authorNames}`);
+  }
+
+  if (editorNames) {
+    parts.push(`Edited with ${editorNames}`);
+  }
+
+  return parts.length > 0 ? ` ${parts.join(". ")}.` : "";
+}
 
 async function getStableVersion(): Promise<string | null> {
   try {
@@ -43,7 +60,7 @@ export async function GET() {
     "",
     ...posts.map(
       (post) =>
-        `- [${post.title}](${absoluteUrl(`/blog/${post.slug}/llms.txt`)}): ${post.description}`,
+        `- [${post.title}](${absoluteUrl(`/blog/${post.slug}/llms.txt`)}): ${post.description}${attributionForPost(post)}`,
     ),
     "",
   ];

--- a/components/blog/author-byline.tsx
+++ b/components/blog/author-byline.tsx
@@ -1,0 +1,34 @@
+import { Fragment } from "react";
+
+import type { BlogAuthor } from "@/lib/authors";
+
+type BlogAuthorBylineProps = {
+  authors: BlogAuthor[];
+  className?: string;
+};
+
+export function BlogAuthorByline({
+  authors,
+  className = "font-mono text-xs text-secondary",
+}: BlogAuthorBylineProps) {
+  if (authors.length === 0) {
+    return null;
+  }
+
+  return (
+    <span className={className}>
+      By{" "}
+      {authors.map((author, index) => (
+        <Fragment key={author.id}>
+          {index > 0 ? (index === authors.length - 1 ? " and " : ", ") : null}
+          <a
+            href={author.url}
+            className="transition-colors hover:text-on-surface"
+          >
+            {author.name}
+          </a>
+        </Fragment>
+      ))}
+    </span>
+  );
+}

--- a/components/blog/post-card.tsx
+++ b/components/blog/post-card.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 
+import { BlogAuthorByline } from "@/components/blog/author-byline";
 import { BlogTagList } from "@/components/blog/tag-list";
 import { formatPostDate, type BlogPostSummary } from "@/lib/blog";
 
@@ -20,6 +21,15 @@ export function BlogPostCard({ post }: BlogPostCardProps) {
         >
           {formatPostDate(post.date)}
         </time>
+        {post.authors.length > 0 ? (
+          <>
+            <span className="h-1 w-1 bg-outline-variant" aria-hidden="true" />
+            <BlogAuthorByline
+              authors={post.authors}
+              className="font-mono text-[11px] text-secondary"
+            />
+          </>
+        ) : null}
         {post.tags.length > 0 ? (
           <span
             className="h-1 w-1 bg-outline-variant"

--- a/content/blog/nteract-2.0.mdx
+++ b/content/blog/nteract-2.0.mdx
@@ -3,6 +3,11 @@ title: "nteract 2.0"
 description: "A ground-up rebuild of the notebook app. New runtime, new architecture, new everything."
 date: 2026-03-24
 published: true
+authors: [kyle]
+editors:
+  - Safia Abdalla
+  - Anil Kulkarni
+  - Krish Pandya
 tags:
   - nteract
   - release

--- a/content/blog/nteract-2.0.mdx
+++ b/content/blog/nteract-2.0.mdx
@@ -4,10 +4,6 @@ description: "A ground-up rebuild of the notebook app. New runtime, new architec
 date: 2026-03-24
 published: true
 authors: [kyle]
-editors:
-  - Safia Abdalla
-  - Anil Kulkarni
-  - Krish Pandya
 tags:
   - nteract
   - release
@@ -17,6 +13,8 @@ coverVideo: "https://pub-d6c6294d12e242e7acb5f8d1eaf78e06.r2.dev/tada.mp4"
 ---
 
 Today we're releasing nteract 2.0. It's a ground-up rebuild of the [much-loved notebook app](https://github.com/nteract/archived-desktop-app). Here's what we built and why.
+
+Editing contributions for this post came from Safia Abdalla, Anil Kulkarni, and Krish Pandya.
 
 <video src="https://pub-d6c6294d12e242e7acb5f8d1eaf78e06.r2.dev/tada.mp4" autoPlay muted loop playsInline />
 

--- a/content/blog/nteract-2.0.mdx
+++ b/content/blog/nteract-2.0.mdx
@@ -14,8 +14,6 @@ coverVideo: "https://pub-d6c6294d12e242e7acb5f8d1eaf78e06.r2.dev/tada.mp4"
 
 Today we're releasing nteract 2.0. It's a ground-up rebuild of the [much-loved notebook app](https://github.com/nteract/archived-desktop-app). Here's what we built and why.
 
-Editing contributions for this post came from Safia Abdalla, Anil Kulkarni, and Krish Pandya.
-
 <video src="https://pub-d6c6294d12e242e7acb5f8d1eaf78e06.r2.dev/tada.mp4" autoPlay muted loop playsInline />
 
 ## What is nteract?
@@ -119,5 +117,7 @@ Your agent gets full access to:
 * [More Rich Media](https://github.com/nteract/nteract/milestone/6): support GeoJSON, Vega/Vegalite, Plotly out of the box
 
 We'd love to hear what you want to build with it. [Drop us an issue on GitHub](https://github.com/nteract/nteract/issues).
+
+_Thank you to Safia Abdalla, Anil Kulkarni, and Krish Pandya for reviewing this post and helping make it better._
 
 <BlogCTA />

--- a/content/blog/security.mdx
+++ b/content/blog/security.mdx
@@ -3,6 +3,7 @@ title: "Securing Notebooks"
 description: "Remote Code Execution is the Feature. Lock it down."
 date: 2026-04-07
 published: true
+author: kyle
 tags:
   - security
   - architecture

--- a/lib/authors.ts
+++ b/lib/authors.ts
@@ -1,0 +1,54 @@
+export type BlogAuthor = {
+  id: string;
+  name: string;
+  url: string;
+  image?: string;
+  role?: string;
+};
+
+export const blogAuthors = {
+  kyle: {
+    id: "kyle",
+    name: "Kyle Kelley",
+    url: "https://github.com/rgbkrk",
+    image: "https://github.com/rgbkrk.png",
+    role: "Project Jupyter and nteract contributor",
+  },
+} as const satisfies Record<string, BlogAuthor>;
+
+export type BlogAuthorId = keyof typeof blogAuthors;
+
+export function resolveBlogAuthors(
+  authorIds: string[],
+  sourceLabel: string,
+): BlogAuthor[] {
+  return authorIds.map((id) => {
+    const author = (blogAuthors as Record<string, BlogAuthor | undefined>)[id];
+
+    if (!author) {
+      throw new Error(`Unknown blog author "${id}" in ${sourceLabel}`);
+    }
+
+    return author;
+  });
+}
+
+export function formatNameList(names: string[]) {
+  if (names.length === 0) {
+    return "";
+  }
+
+  if (names.length === 1) {
+    return names[0];
+  }
+
+  if (names.length === 2) {
+    return `${names[0]} and ${names[1]}`;
+  }
+
+  return `${names.slice(0, -1).join(", ")}, and ${names[names.length - 1]}`;
+}
+
+export function formatAuthorNames(authors: BlogAuthor[]) {
+  return formatNameList(authors.map((author) => author.name));
+}

--- a/lib/authors.ts
+++ b/lib/authors.ts
@@ -33,7 +33,7 @@ export function resolveBlogAuthors(
   });
 }
 
-export function formatNameList(names: string[]) {
+function formatNameList(names: string[]) {
   if (names.length === 0) {
     return "";
   }

--- a/lib/blog.test.ts
+++ b/lib/blog.test.ts
@@ -25,4 +25,21 @@ describe("blog content utilities", () => {
     expect(post).not.toBeNull();
     expect(post?.published).toBe(true);
   });
+
+  it("resolves post authors and editor acknowledgments", async () => {
+    const security = await getPostBySlug("security");
+    const release = await getPostBySlug("nteract-2.0");
+
+    expect(security?.authors.map((author) => author.name)).toEqual([
+      "Kyle Kelley",
+    ]);
+    expect(release?.authors.map((author) => author.name)).toEqual([
+      "Kyle Kelley",
+    ]);
+    expect(release?.editors).toEqual([
+      "Safia Abdalla",
+      "Anil Kulkarni",
+      "Krish Pandya",
+    ]);
+  });
 });

--- a/lib/blog.test.ts
+++ b/lib/blog.test.ts
@@ -26,7 +26,7 @@ describe("blog content utilities", () => {
     expect(post?.published).toBe(true);
   });
 
-  it("resolves post authors and editor acknowledgments", async () => {
+  it("resolves post authors", async () => {
     const security = await getPostBySlug("security");
     const release = await getPostBySlug("nteract-2.0");
 
@@ -35,11 +35,6 @@ describe("blog content utilities", () => {
     ]);
     expect(release?.authors.map((author) => author.name)).toEqual([
       "Kyle Kelley",
-    ]);
-    expect(release?.editors).toEqual([
-      "Safia Abdalla",
-      "Anil Kulkarni",
-      "Krish Pandya",
     ]);
   });
 });

--- a/lib/blog.ts
+++ b/lib/blog.ts
@@ -17,7 +17,6 @@ export type BlogPostFrontmatter = {
   coverVideo?: string;
   ogImage?: string;
   authors: BlogAuthor[];
-  editors: string[];
 };
 
 export type BlogPostSummary = BlogPostFrontmatter & {
@@ -106,7 +105,6 @@ function parseFrontmatter(fileName: string, data: Record<string, unknown>) {
     data.published === undefined ? true : Boolean(data.published);
   const tags = normalizeTags(data.tags, fileName);
   const authors = normalizeAuthors(data, fileName);
-  const editors = normalizeStringList(data.editors, "editors", fileName);
   const coverImage =
     typeof data.coverImage === "string" && data.coverImage.trim().length > 0
       ? data.coverImage.trim()
@@ -130,7 +128,6 @@ function parseFrontmatter(fileName: string, data: Record<string, unknown>) {
     coverVideo,
     ogImage,
     authors,
-    editors,
   } satisfies BlogPostFrontmatter;
 }
 

--- a/lib/blog.ts
+++ b/lib/blog.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 
 import matter from "gray-matter";
 
-import { absoluteUrl } from "@/lib/site";
+import { resolveBlogAuthors, type BlogAuthor } from "@/lib/authors";
 
 const BLOG_DIRECTORY = path.join(process.cwd(), "content/blog");
 
@@ -16,6 +16,8 @@ export type BlogPostFrontmatter = {
   coverImage?: string;
   coverVideo?: string;
   ogImage?: string;
+  authors: BlogAuthor[];
+  editors: string[];
 };
 
 export type BlogPostSummary = BlogPostFrontmatter & {
@@ -32,7 +34,7 @@ type BlogQueryOptions = {
 
 function assertString(
   value: unknown,
-  field: keyof BlogPostFrontmatter,
+  field: string,
   fileName: string,
 ) {
   if (typeof value !== "string" || value.trim().length === 0) {
@@ -53,22 +55,47 @@ function normalizeDate(value: unknown, fileName: string) {
 }
 
 function normalizeTags(value: unknown, fileName: string) {
+  return normalizeStringList(value, "tags", fileName, { splitComma: true });
+}
+
+function normalizeStringList(
+  value: unknown,
+  field: string,
+  fileName: string,
+  options: { splitComma?: boolean } = {},
+) {
   if (value == null) {
     return [];
   }
 
   if (Array.isArray(value)) {
-    return value.map((entry) => assertString(entry, "tags", fileName));
+    return value.map((entry) => assertString(entry, field, fileName));
   }
 
   if (typeof value === "string") {
+    if (!options.splitComma) {
+      return [assertString(value, field, fileName)];
+    }
+
     return value
       .split(",")
       .map((tag) => tag.trim())
       .filter(Boolean);
   }
 
-  throw new Error(`Expected "tags" to be a string or string[] in ${fileName}`);
+  throw new Error(
+    `Expected "${field}" to be a string or string[] in ${fileName}`,
+  );
+}
+
+function normalizeAuthors(data: Record<string, unknown>, fileName: string) {
+  const authorIds = normalizeStringList(
+    data.authors ?? data.author,
+    "authors",
+    fileName,
+  );
+
+  return resolveBlogAuthors(authorIds, fileName);
 }
 
 function parseFrontmatter(fileName: string, data: Record<string, unknown>) {
@@ -78,6 +105,8 @@ function parseFrontmatter(fileName: string, data: Record<string, unknown>) {
   const published =
     data.published === undefined ? true : Boolean(data.published);
   const tags = normalizeTags(data.tags, fileName);
+  const authors = normalizeAuthors(data, fileName);
+  const editors = normalizeStringList(data.editors, "editors", fileName);
   const coverImage =
     typeof data.coverImage === "string" && data.coverImage.trim().length > 0
       ? data.coverImage.trim()
@@ -100,6 +129,8 @@ function parseFrontmatter(fileName: string, data: Record<string, unknown>) {
     coverImage,
     coverVideo,
     ogImage,
+    authors,
+    editors,
   } satisfies BlogPostFrontmatter;
 }
 


### PR DESCRIPTION
## Summary

- Add a lightweight blog author registry and frontmatter support for `author` / `authors`
- Attribute recent Kyle-authored posts in blog pages, metadata, RSS, and `llms.txt`
- Add a restrained editor acknowledgment for the nteract 2.0 post

## Verification

- `pnpm test lib/blog.test.ts 'app/(blog)/blog/page.test.tsx'`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm build`
