### PR TITLE
Unify nteract.io on one design system

### DIFF
--- a/app/(blog)/blog/[slug]/page.tsx
+++ b/app/(blog)/blog/[slug]/page.tsx
@@ -81,73 +81,45 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
   const { default: Content } = await import(`@/content/blog/${slug}.mdx`);
 
   return (
-    <div className="px-6 pb-24 pt-12 md:px-12">
-      <article className="mx-auto max-w-4xl">
+    <div className="mx-auto w-full max-w-[42.5rem] px-6 pb-16 pt-14 sm:px-10">
+      <article>
         {/* Article Header */}
-        <header className="mb-12">
-          <div className="mb-6 flex items-center gap-4">
+        <header className="mb-9">
+          <div className="mb-6 flex items-center gap-3 font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
             <Link
               href="/blog"
-              className="font-mono text-[11px] uppercase tracking-widest text-[#a993d1] transition-colors hover:text-on-surface"
+              className="text-foreground transition-colors hover:text-muted-foreground"
             >
               ← Blog
             </Link>
-            <div className="h-px flex-grow bg-outline-variant/20" />
-            <time
-              dateTime={post.date}
-              className="font-mono text-xs uppercase tracking-widest text-secondary"
-            >
-              {formatPostDate(post.date)}
-            </time>
+            <div className="h-px flex-grow bg-border" />
+            <time dateTime={post.date}>{formatPostDate(post.date)}</time>
             {post.authors.length > 0 ? (
               <>
-                <div className="h-px w-4 bg-outline-variant/20" />
+                <span aria-hidden="true">·</span>
                 <BlogAuthorByline authors={post.authors} />
               </>
             ) : null}
           </div>
 
-          <h1 className="mb-6 font-headline text-6xl font-bold leading-[0.9] tracking-tighter text-on-surface md:text-8xl">
+          <h1 className="mb-3 text-[32px] font-bold leading-[1.05] tracking-[-0.03em] text-foreground sm:text-[40px]">
             {post.title}
           </h1>
 
-          {(() => {
-            const dot = post.description.indexOf(".");
-            if (dot === -1) {
-              return (
-                <p className="mb-6 max-w-2xl text-xl leading-snug text-on-surface/60">
-                  {post.description}
-                </p>
-              );
-            }
-            const lead = post.description.slice(0, dot + 1);
-            const rest = post.description.slice(dot + 1).trim();
-            return (
-              <div className="mb-6 max-w-2xl space-y-2">
-                <p className="font-headline text-2xl font-semibold tracking-tight text-on-surface/80 md:text-3xl">
-                  {lead}
-                </p>
-                {rest && (
-                  <p className="font-mono text-xs uppercase tracking-[0.25em] text-on-surface-variant">
-                    {rest}
-                  </p>
-                )}
-              </div>
-            );
-          })()}
+          <p className="mb-6 text-lg leading-normal text-muted-foreground">
+            {post.description}
+          </p>
 
-          <div className="flex flex-wrap items-center gap-6">
-            <BlogTagList tags={post.tags} />
-          </div>
+          <BlogTagList tags={post.tags} />
         </header>
 
         {/* Cover image */}
         {post.coverImage ? (
-          <section className="mb-16">
-            <div className="aspect-video w-full overflow-hidden bg-surface-container-low">
+          <section className="mb-12">
+            <div className="overflow-hidden rounded-lg border border-border">
               <img
                 alt={post.title}
-                className="h-full w-full object-cover"
+                className="block w-full"
                 src={post.coverImage}
               />
             </div>
@@ -155,19 +127,19 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
         ) : null}
 
         {/* Body Prose */}
-        <Prose className="prose-invert mx-auto max-w-2xl">
+        <Prose>
           <Content />
         </Prose>
 
         {/* Post footer */}
-        <div className="mx-auto mt-16 flex max-w-2xl items-center gap-4">
+        <div className="mt-14 flex items-center gap-3 font-mono text-[11px] uppercase tracking-[0.14em]">
           <Link
             href="/blog"
-            className="font-mono text-[11px] uppercase tracking-widest text-[#a993d1] transition-colors hover:text-on-surface"
+            className="text-foreground transition-colors hover:text-muted-foreground"
           >
             ← All posts
           </Link>
-          <div className="h-px flex-grow bg-outline-variant/20" />
+          <div className="h-px flex-grow bg-border" />
         </div>
       </article>
     </div>

--- a/app/(blog)/blog/page.test.tsx
+++ b/app/(blog)/blog/page.test.tsx
@@ -25,6 +25,7 @@ describe("BlogPage", () => {
         published: true,
         tags: ["MDX"],
         authors: [],
+        composition: { code: 3, markdown: 12, raw: 0 },
       },
     ]);
 
@@ -36,8 +37,7 @@ describe("BlogPage", () => {
     expect(
       screen.getByRole("link", { name: /Shipping a local-first blog/ })
     ).toHaveAttribute("href", "/blog/shipping-a-local-first-blog");
-    expect(screen.getByText("RSS")).toBeInTheDocument();
-    expect(screen.getByText("Read the post →")).toBeInTheDocument();
+    expect(screen.getByText("Read the post")).toBeInTheDocument();
   });
 
   it("shows the empty state when no posts are published", async () => {

--- a/app/(blog)/blog/page.tsx
+++ b/app/(blog)/blog/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { BlogAuthorByline } from "@/components/blog/author-byline";
 import { BlogPostCard } from "@/components/blog/post-card";
 import { BlogTagList } from "@/components/blog/tag-list";
+import { buttonVariants } from "@/components/ui/button-variants";
 import { formatPostDate, getAllPosts } from "@/lib/blog";
 import { absoluteUrl, siteConfig } from "@/lib/site";
 
@@ -35,129 +36,81 @@ export default async function BlogPage() {
   const [latest, ...rest] = posts;
 
   return (
-    <div className="px-6 pb-24 pt-12 md:px-12">
-      <section className="mx-auto max-w-4xl">
-        {latest ? (
-          <>
-            <div className="mb-6 flex items-center gap-4">
-              <Link
-                href="/"
-                className="font-mono text-[11px] uppercase tracking-widest text-[#a993d1] transition-colors hover:text-on-surface"
-              >
-                ← Home
-              </Link>
-              <div className="h-px flex-grow bg-outline-variant/20" />
-              <time
-                dateTime={latest.date}
-                className="font-mono text-xs uppercase tracking-widest text-secondary"
-              >
-                {formatPostDate(latest.date)}
-              </time>
-              {latest.authors.length > 0 ? (
-                <>
-                  <div className="h-px w-4 bg-outline-variant/20" />
-                  <BlogAuthorByline authors={latest.authors} />
-                </>
-              ) : null}
-              <div className="h-px w-4 bg-outline-variant/20" />
-              <a
-                href={siteConfig.links.rss}
-                className="font-mono text-[11px] uppercase tracking-widest text-outline-variant transition-colors hover:text-on-surface"
-              >
-                RSS
-              </a>
-            </div>
-
-            <Link href={`/blog/${latest.slug}`} className="group block">
-              <h1
-                className={`mb-6 font-headline font-bold leading-[0.9] tracking-tighter text-on-surface transition-colors group-hover:text-secondary ${latest.coverVideo || latest.coverImage ? "text-6xl md:text-8xl" : "text-4xl md:text-5xl"}`}
-              >
-                {latest.title}
-              </h1>
-
-              {(() => {
-                const dot = latest.description.indexOf(".");
-                if (dot === -1) {
-                  return (
-                    <p className="mb-6 max-w-2xl text-xl leading-snug text-on-surface/60">
-                      {latest.description}
-                    </p>
-                  );
-                }
-                const lead = latest.description.slice(0, dot + 1);
-                const rest2 = latest.description.slice(dot + 1).trim();
-                return (
-                  <div className="mb-6 max-w-2xl space-y-2">
-                    <p
-                      className={`font-headline font-semibold tracking-tight text-on-surface/80 ${latest.coverVideo || latest.coverImage ? "text-2xl md:text-3xl" : "text-lg md:text-xl"}`}
-                    >
-                      {lead}
-                    </p>
-                    {rest2 && (
-                      <p className="font-mono text-xs uppercase tracking-[0.25em] text-on-surface-variant">
-                        {rest2}
-                      </p>
-                    )}
-                  </div>
-                );
-              })()}
-
-              <div className="flex flex-wrap items-center gap-6">
-                <BlogTagList tags={latest.tags} />
-                <span className="font-mono text-[11px] uppercase tracking-widest text-secondary transition-colors group-hover:text-on-surface">
-                  Read the post →
-                </span>
-              </div>
-            </Link>
-
-            {/* Hero preview — driven by coverVideo / coverImage frontmatter */}
-            {latest.coverVideo ? (
-              <Link
-                href={`/blog/${latest.slug}`}
-                className="mt-10 block overflow-hidden"
-              >
-                <video
-                  src={latest.coverVideo}
-                  autoPlay
-                  muted
-                  loop
-                  playsInline
-                  className="w-full"
-                />
-              </Link>
-            ) : latest.coverImage ? (
-              <Link
-                href={`/blog/${latest.slug}`}
-                className="mt-10 block overflow-hidden"
-              >
-                <img
-                  src={latest.coverImage}
-                  alt={latest.title}
-                  className="w-full"
-                />
-              </Link>
+    <div className="mx-auto w-full max-w-[45rem] px-6 pb-16 pt-14 sm:px-10">
+      {latest ? (
+        <>
+          <div className="mb-7 flex items-center gap-3 font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
+            <span>Blog</span>
+            <div className="h-px flex-grow bg-border" />
+            <time dateTime={latest.date}>{formatPostDate(latest.date)}</time>
+            {latest.authors.length > 0 ? (
+              <>
+                <span aria-hidden="true">·</span>
+                <BlogAuthorByline authors={latest.authors} />
+              </>
             ) : null}
-          </>
-        ) : (
-          <div className="bg-surface-container-low px-6 py-10 text-on-surface-variant">
-            The first post is still in draft. Check back soon.
           </div>
-        )}
 
-        {rest.length > 0 && (
-          <div className="mt-16 space-y-4">
-            <div className="mb-6 flex items-center gap-4">
-              <span className="font-mono text-[11px] uppercase tracking-widest text-outline-variant">
-                Older posts
-              </span>
-              <div className="h-px flex-grow bg-outline-variant/20" />
-            </div>
-            {rest.map((post) => (
-              <BlogPostCard key={post.slug} post={post} />
-            ))}
+          <Link href={`/blog/${latest.slug}`} className="block">
+            <h1 className="mb-3.5 text-[34px] font-bold leading-[1.02] tracking-[-0.03em] text-foreground sm:text-[44px]">
+              {latest.title}
+            </h1>
+            <p className="mb-5 max-w-[560px] text-[19px] leading-[1.45] text-muted-foreground">
+              {latest.description}
+            </p>
+          </Link>
+
+          <div className="mb-6 flex flex-wrap items-center gap-2.5">
+            <BlogTagList tags={latest.tags} />
+            <div className="flex-grow" />
+            <Link
+              href={`/blog/${latest.slug}`}
+              className={buttonVariants({ variant: "outline", size: "sm" })}
+            >
+              Read the post
+            </Link>
           </div>
-        )}
-      </section>
+
+          {/* Hero preview — driven by coverVideo / coverImage frontmatter */}
+          {latest.coverVideo ? (
+            <Link
+              href={`/blog/${latest.slug}`}
+              className="block overflow-hidden rounded-lg border border-border"
+            >
+              <video
+                src={latest.coverVideo}
+                autoPlay
+                muted
+                loop
+                playsInline
+                className="block w-full"
+              />
+            </Link>
+          ) : latest.coverImage ? (
+            <Link
+              href={`/blog/${latest.slug}`}
+              className="block overflow-hidden rounded-lg border border-border"
+            >
+              <img src={latest.coverImage} alt={latest.title} className="block w-full" />
+            </Link>
+          ) : null}
+        </>
+      ) : (
+        <div className="rounded-lg border border-border bg-card px-6 py-10 text-muted-foreground">
+          The first post is still in draft. Check back soon.
+        </div>
+      )}
+
+      {rest.length > 0 && (
+        <div className="mt-12 flex flex-col gap-3">
+          <div className="font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
+            Older posts
+          </div>
+          {rest.map((post) => (
+            <BlogPostCard key={post.slug} post={post} />
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/app/(blog)/layout.tsx
+++ b/app/(blog)/layout.tsx
@@ -4,12 +4,14 @@ import type { ReactNode } from "react";
 import { SiteFooter, SiteHeader } from "@/components/site-shell";
 
 export const viewport: Viewport = {
-  themeColor: "#ffffff",
+  themeColor: "#0a0a0a",
 };
 
+// Ink surface: the blog's graphics (diagram islands, cover videos) are
+// composed against the dark palette.
 export default function BlogLayout({ children }: { children: ReactNode }) {
   return (
-    <div className="flex min-h-screen flex-col bg-background text-foreground">
+    <div className="dark flex min-h-screen flex-col bg-background text-foreground">
       <SiteHeader active="blog" />
       <main className="flex-1">{children}</main>
       <SiteFooter />

--- a/app/(blog)/layout.tsx
+++ b/app/(blog)/layout.tsx
@@ -1,14 +1,18 @@
-import type { Metadata } from "next";
+import type { Viewport } from "next";
 import type { ReactNode } from "react";
 
-export const metadata: Metadata = {
-  themeColor: "#0e0e0e",
+import { SiteFooter, SiteHeader } from "@/components/site-shell";
+
+export const viewport: Viewport = {
+  themeColor: "#ffffff",
 };
 
 export default function BlogLayout({ children }: { children: ReactNode }) {
   return (
-    <div className="relative min-h-screen bg-surface text-on-surface selection:bg-primary/30">
-      <main className="relative">{children}</main>
+    <div className="flex min-h-screen flex-col bg-background text-foreground">
+      <SiteHeader active="blog" />
+      <main className="flex-1">{children}</main>
+      <SiteFooter />
     </div>
   );
 }

--- a/app/(changelog)/changelog/[version]/page.tsx
+++ b/app/(changelog)/changelog/[version]/page.tsx
@@ -15,7 +15,7 @@ import {
 import { absoluteUrl } from "@/lib/site";
 
 export const viewport: Viewport = {
-  themeColor: "#0a0a0a",
+  themeColor: "#ffffff",
 };
 
 type ChangelogVersionPageProps = {
@@ -94,7 +94,7 @@ export default async function ChangelogVersionPage({
   );
 
   return (
-    <div className="dark flex min-h-screen flex-col bg-background text-foreground">
+    <div className="flex min-h-screen flex-col bg-background text-foreground">
       <SiteHeader active="changelog" />
 
       <main className="mx-auto w-full max-w-[45rem] flex-1 px-6 pb-[72px] pt-16 sm:px-10">

--- a/app/(changelog)/changelog/[version]/page.tsx
+++ b/app/(changelog)/changelog/[version]/page.tsx
@@ -1,16 +1,22 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { headers } from "next/headers";
 import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
 
 import { ChangelogTagList } from "@/components/changelog/tag-list";
+import { RuntimeStatusDot } from "@/components/elements/runtime-status-dot";
 import { Prose } from "@/components/prose";
+import { SiteFooter, SiteHeader } from "@/components/site-shell";
 import {
   formatEntryDate,
   resolveVersionParam,
   shouldShowDrafts,
 } from "@/lib/changelog";
 import { absoluteUrl } from "@/lib/site";
+
+export const viewport: Viewport = {
+  themeColor: "#0a0a0a",
+};
 
 type ChangelogVersionPageProps = {
   params: Promise<{
@@ -88,115 +94,125 @@ export default async function ChangelogVersionPage({
   );
 
   return (
-    <div className="px-6 pb-24 pt-12 md:px-12">
-      <article className="mx-auto max-w-4xl">
-        {/* Header */}
-        <header className="mb-12">
-          <div className="mb-6 flex items-center gap-4">
+    <div className="dark flex min-h-screen flex-col bg-background text-foreground">
+      <SiteHeader active="changelog" />
+
+      <main className="mx-auto w-full max-w-[45rem] flex-1 px-6 pb-[72px] pt-16 sm:px-10">
+        <article>
+          {/* Header */}
+          <header className="mb-10">
+            <div className="mb-7 flex items-center gap-3 font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
+              <Link
+                href="/changelog"
+                className="text-foreground transition-colors hover:text-muted-foreground"
+              >
+                ← Changelog
+              </Link>
+              <div className="h-px flex-grow bg-border" />
+              <time dateTime={entry.date}>{formatEntryDate(entry)}</time>
+            </div>
+
+            <div className="mb-4 flex items-center gap-4">
+              <span className="font-mono text-[32px] font-semibold tracking-[-0.02em] text-foreground">
+                {entry.version}
+              </span>
+              <RuntimeStatusDot
+                status={entry.published ? "ready" : "executing"}
+                showLabel
+                label={entry.published ? "shipped" : "in progress"}
+              />
+            </div>
+
+            <h1 className="mb-3 text-[32px] font-bold leading-[1.05] tracking-[-0.03em] text-foreground sm:text-[40px]">
+              {entry.title}
+            </h1>
+
+            <p className="mb-6 max-w-[560px] text-lg leading-normal text-muted-foreground">
+              {entry.summary}
+            </p>
+
+            <ChangelogTagList tags={entry.tags} />
+          </header>
+
+          {/* Hero */}
+          {entry.heroVideo ? (
+            <section className="mb-12">
+              <div className="overflow-hidden rounded-lg border border-border">
+                <video
+                  src={entry.heroVideo}
+                  poster={entry.heroVideoPoster}
+                  autoPlay
+                  muted
+                  loop
+                  playsInline
+                  className="block w-full"
+                />
+              </div>
+            </section>
+          ) : entry.heroImage ? (
+            <section className="mb-12">
+              <div className="aspect-video w-full overflow-hidden rounded-lg border border-border bg-card">
+                <img
+                  alt={entry.title}
+                  className="h-full w-full object-cover"
+                  src={entry.heroImage}
+                />
+              </div>
+            </section>
+          ) : null}
+
+          {/* Highlights */}
+          {entry.highlights.length > 0 ? (
+            <section className="mb-12">
+              <h2 className="mb-4 text-2xl font-bold tracking-[-0.02em]">
+                Highlights
+              </h2>
+              <ul className="flex flex-col gap-2.5">
+                {entry.highlights.map((highlight) => (
+                  <li
+                    key={highlight}
+                    className="flex gap-2.5 text-[15.5px] leading-normal"
+                  >
+                    <span
+                      aria-hidden="true"
+                      className="mt-2 h-[5px] w-[5px] shrink-0 rounded-[1px] bg-foreground"
+                    />
+                    <span>{highlight}</span>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ) : null}
+
+          {/* Body — narrative + full technical changelog */}
+          <Prose>
+            <Content />
+          </Prose>
+
+          {/* Footer */}
+          <div className="mt-14 flex flex-wrap items-center gap-3 font-mono text-[11px] uppercase tracking-[0.14em]">
             <Link
               href="/changelog"
-              className="font-mono text-[11px] uppercase tracking-widest text-[var(--accent)] transition-colors hover:text-[var(--ink)]"
+              className="text-foreground transition-colors hover:text-muted-foreground"
             >
-              ← Changelog
+              ← All releases
             </Link>
-            <div className="h-px flex-grow bg-[var(--rule)]" />
-            <time
-              dateTime={entry.date}
-              className="font-mono text-xs uppercase tracking-widest text-[var(--accent)]"
-            >
-              {formatEntryDate(entry)}
-            </time>
+            <div className="h-px flex-grow bg-border" />
+            {entry.githubReleaseUrl ? (
+              <a
+                href={entry.githubReleaseUrl}
+                className="text-muted-foreground transition-colors hover:text-foreground"
+                rel="noreferrer"
+                target="_blank"
+              >
+                GitHub release →
+              </a>
+            ) : null}
           </div>
+        </article>
+      </main>
 
-          <div className="mb-4 font-mono text-sm uppercase tracking-[0.25em] text-[var(--accent)]">
-            nteract {entry.version}
-          </div>
-
-          <h1 className="text-[var(--ink)]">{entry.title}</h1>
-
-          <p className="mb-6 mt-2 max-w-2xl text-xl leading-snug text-[var(--muted)]">
-            {entry.summary}
-          </p>
-
-          <div className="flex flex-wrap items-center gap-6">
-            <ChangelogTagList tags={entry.tags} />
-          </div>
-        </header>
-
-        {/* Hero */}
-        {entry.heroVideo ? (
-          <section className="mb-16">
-            <div className="overflow-hidden border border-[var(--rule)]">
-              <video
-                src={entry.heroVideo}
-                poster={entry.heroVideoPoster}
-                autoPlay
-                muted
-                loop
-                playsInline
-                className="w-full"
-              />
-            </div>
-          </section>
-        ) : entry.heroImage ? (
-          <section className="mb-16">
-            <div className="aspect-video w-full overflow-hidden border border-[var(--rule)] bg-[var(--paper-elevated)]">
-              <img
-                alt={entry.title}
-                className="h-full w-full object-cover"
-                src={entry.heroImage}
-              />
-            </div>
-          </section>
-        ) : null}
-
-        {/* Highlights */}
-        {entry.highlights.length > 0 ? (
-          <section className="mx-auto mb-16 max-w-2xl">
-            <h2 className="mb-5 text-2xl text-[var(--ink)]">Highlights</h2>
-            <ul className="space-y-3">
-              {entry.highlights.map((highlight) => (
-                <li
-                  key={highlight}
-                  className="flex gap-3 text-lg text-[var(--ink)]"
-                >
-                  <span
-                    aria-hidden="true"
-                    className="mt-[0.6rem] h-1.5 w-1.5 shrink-0 bg-[var(--accent)]"
-                  />
-                  <span className="leading-snug">{highlight}</span>
-                </li>
-              ))}
-            </ul>
-          </section>
-        ) : null}
-
-        {/* Body — narrative + full technical changelog */}
-        <Prose className="nteract-prose mx-auto max-w-2xl">
-          <Content />
-        </Prose>
-
-        {/* Footer */}
-        <div className="mx-auto mt-16 flex max-w-2xl flex-wrap items-center gap-4">
-          <Link
-            href="/changelog"
-            className="font-mono text-[11px] uppercase tracking-widest text-[var(--accent)] transition-colors hover:text-[var(--ink)]"
-          >
-            ← All releases
-          </Link>
-          <div className="h-px flex-grow bg-[var(--rule)]" />
-          {entry.githubReleaseUrl ? (
-            <a
-              href={entry.githubReleaseUrl}
-              className="font-mono text-[11px] uppercase tracking-widest text-[var(--muted)] transition-colors hover:text-[var(--ink)]"
-              rel="noreferrer"
-              target="_blank"
-            >
-              GitHub release →
-            </a>
-          ) : null}
-        </div>
-      </article>
+      <SiteFooter />
     </div>
   );
 }

--- a/app/(changelog)/changelog/page.tsx
+++ b/app/(changelog)/changelog/page.tsx
@@ -1,8 +1,9 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { headers } from "next/headers";
 import Link from "next/link";
 
 import { ChangelogFeedEntry } from "@/components/changelog/changelog-feed-entry";
+import { SiteFooter, SiteHeader } from "@/components/site-shell";
 import { getAllEntries, shouldShowDrafts } from "@/lib/changelog";
 import { absoluteUrl, siteConfig } from "@/lib/site";
 
@@ -11,7 +12,7 @@ import { absoluteUrl, siteConfig } from "@/lib/site";
 export const dynamic = "force-dynamic";
 
 const description =
-  "Local-first notebooks, built from the ground up for mingling with agents. Realtime collab with a colorful, jazzy streak. Here's how it gets better, release by release.";
+  "Local-first notebooks, built from the ground up for mingling with agents. Here's how it gets better, release by release.";
 
 // Handcrafted generic changelog card. Intentionally not a per-release image:
 // the index represents the whole changelog, so it keeps its own card.
@@ -41,6 +42,10 @@ export const metadata: Metadata = {
   },
 };
 
+export const viewport: Viewport = {
+  themeColor: "#0a0a0a",
+};
+
 export default async function ChangelogPage() {
   const host = (await headers()).get("host");
   const entries = await getAllEntries({
@@ -57,41 +62,36 @@ export default async function ChangelogPage() {
   );
 
   return (
-    <div className="px-6 pb-24 pt-12 md:px-12">
-      <section className="mx-auto max-w-4xl">
-        {/* Header */}
-        <div className="mb-6 flex items-center gap-4">
-          <Link
-            href="/"
-            className="font-mono text-[11px] uppercase tracking-widest text-[var(--accent)] transition-colors hover:text-[var(--ink)]"
-          >
-            ← Home
-          </Link>
-          <div className="h-px flex-grow bg-[var(--rule)]" />
+    <div className="dark flex min-h-screen flex-col bg-background text-foreground">
+      <SiteHeader active="changelog" />
+
+      <main className="mx-auto w-full max-w-[45rem] flex-1 px-6 pb-[72px] pt-16 sm:px-10">
+        <div className="mb-7 flex items-center gap-3 font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
+          <span>Changelog</span>
+          <div className="h-px flex-grow bg-border" />
           <Link
             href="/changelog/print"
-            className="font-mono text-[11px] uppercase tracking-widest text-[var(--accent)] transition-colors hover:text-[var(--ink)]"
+            className="transition-colors hover:text-foreground"
           >
             Print
           </Link>
           <a
             href="/changelog/feed.xml"
-            className="font-mono text-[11px] uppercase tracking-widest text-[var(--muted)] transition-colors hover:text-[var(--ink)]"
+            className="transition-colors hover:text-foreground"
           >
             RSS
           </a>
         </div>
 
-        <h1 className="text-[var(--ink)]">Changelog</h1>
-
-        <p className="mb-16 max-w-2xl text-xl leading-snug text-[var(--muted)]">
-          Local-first notebooks, built from the ground up for mingling with
-          agents. Realtime collab with a colorful, jazzy streak. Here&apos;s how
-          it gets better, release by release.
+        <h1 className="mb-3 text-[40px] font-extrabold leading-[0.98] tracking-[-0.04em] sm:text-[56px]">
+          Changelog
+        </h1>
+        <p className="mb-11 max-w-[560px] text-[17px] leading-[1.55] text-muted-foreground">
+          {description}
         </p>
 
         {rendered.length > 0 ? (
-          <div className="space-y-12">
+          <div>
             {rendered.map(({ entry, Content }) => (
               <ChangelogFeedEntry key={entry.version} entry={entry}>
                 <Content />
@@ -99,11 +99,13 @@ export default async function ChangelogPage() {
             ))}
           </div>
         ) : (
-          <div className="border border-[var(--rule)] bg-[var(--paper-elevated)] px-6 py-10 text-[var(--muted)]">
+          <div className="rounded-lg border border-border bg-card px-6 py-10 text-muted-foreground">
             The first release notes are still in draft. Check back soon.
           </div>
         )}
-      </section>
+      </main>
+
+      <SiteFooter />
     </div>
   );
 }

--- a/app/(changelog)/changelog/page.tsx
+++ b/app/(changelog)/changelog/page.tsx
@@ -43,7 +43,7 @@ export const metadata: Metadata = {
 };
 
 export const viewport: Viewport = {
-  themeColor: "#0a0a0a",
+  themeColor: "#ffffff",
 };
 
 export default async function ChangelogPage() {
@@ -62,7 +62,7 @@ export default async function ChangelogPage() {
   );
 
   return (
-    <div className="dark flex min-h-screen flex-col bg-background text-foreground">
+    <div className="flex min-h-screen flex-col bg-background text-foreground">
       <SiteHeader active="changelog" />
 
       <main className="mx-auto w-full max-w-[45rem] flex-1 px-6 pb-[72px] pt-16 sm:px-10">

--- a/app/(changelog)/layout.tsx
+++ b/app/(changelog)/layout.tsx
@@ -1,20 +1,11 @@
-import type { Metadata } from "next";
 import type { ReactNode } from "react";
 
-export const metadata: Metadata = {
-  themeColor: "#faf8f3",
-};
-
+// Pass-through: the changelog index and version pages wrap themselves in the
+// Ink (.dark) shell, while /changelog/print stays ink-on-paper for printing.
 export default function ChangelogLayout({
   children,
 }: {
   children: ReactNode;
 }) {
-  // cream-page sets the paper background, ink text, serif headings, and the
-  // scoped --paper/--ink/--accent/--rule/--muted vars the changelog styles use.
-  return (
-    <div className="cream-page relative min-h-screen">
-      <main className="relative">{children}</main>
-    </div>
-  );
+  return <>{children}</>;
 }

--- a/app/agents/page.tsx
+++ b/app/agents/page.tsx
@@ -1,8 +1,9 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import Link from "next/link";
 
-import { CommandBlock, InlineCode, PageHero, StepCard } from "@/components/product/page-primitives";
-import { Container, SiteFooter, SiteHeader } from "@/components/site-shell";
+import { RuntimeStatusDot } from "@/components/elements/runtime-status-dot";
+import { SiteFooter, SiteHeader } from "@/components/site-shell";
+import { buttonVariants } from "@/components/ui/button-variants";
 
 export const metadata: Metadata = {
   title: "Use nteract with agents",
@@ -10,135 +11,123 @@ export const metadata: Metadata = {
     "Install nteract's agent plugins for Claude Code and Codex so agents can work in live notebooks instead of throwaway scripts.",
 };
 
-const claudeCommands = [
-  "/plugin marketplace add nteract/agent-plugins",
-  "/plugin install nteract@nteract       # stable",
-  "/plugin install nightly@nteract       # nightly",
-];
+export const viewport: Viewport = {
+  themeColor: "#0a0a0a",
+};
 
-const codexCommands = [
-  "codex plugin marketplace add nteract/agent-plugins",
-  "# Then run /plugin in Codex and enable nteract or nightly",
-];
+function InlineCode({ children }: { children: React.ReactNode }) {
+  return (
+    <code className="rounded bg-muted px-1.5 py-px font-mono text-[0.9em]">
+      {children}
+    </code>
+  );
+}
+
+function InstallCard({
+  label,
+  children,
+  footnote,
+}: {
+  label: string;
+  children: React.ReactNode;
+  footnote: React.ReactNode;
+}) {
+  return (
+    <div className="overflow-hidden rounded-lg border border-border">
+      <div className="flex items-center justify-between border-b border-border px-4 py-2.5">
+        <span className="font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
+          {label}
+        </span>
+        <RuntimeStatusDot status="ready" />
+      </div>
+      <pre className="overflow-x-auto bg-[oklch(0.09_0_0)] p-4 font-mono text-[12.5px] leading-[1.8] text-foreground">
+        {children}
+      </pre>
+      <div className="px-4 py-3 text-[13.5px] leading-[1.55] text-muted-foreground">
+        {footnote}
+      </div>
+    </div>
+  );
+}
 
 export default function AgentsPage() {
   return (
-    <div className="min-h-screen bg-gray-50 text-gray-900">
-      <SiteHeader />
+    <div className="dark min-h-screen bg-background text-foreground">
+      <SiteHeader active="agents" />
 
-      <main>
-        <Container className="py-16 sm:py-24">
-          <PageHero
-            eyebrow="Agents"
-            title="Use nteract as your agent notebook"
-            subtitle={
+      <main className="mx-auto w-full max-w-[47.5rem] px-6 pb-[72px] pt-16 sm:px-10">
+        <div className="mb-7 flex items-center gap-3 font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
+          <span>Agents</span>
+          <div className="h-px flex-grow bg-border" />
+          <span>claude code · codex</span>
+        </div>
+
+        <h1 className="mb-4 text-[40px] font-extrabold leading-[0.98] tracking-[-0.04em] sm:text-[56px]">
+          Agents: Show Your Work
+        </h1>
+        <p className="mb-12 max-w-[600px] text-lg leading-[1.55] text-muted-foreground">
+          A live notebook for Claude Code and Codex. State persists. Outputs
+          stay rich. Every step is yours to inspect, edit, and keep.
+        </p>
+
+        <div className="mb-12 grid gap-5 sm:grid-cols-2">
+          <InstallCard
+            label="Claude Code"
+            footnote={
               <>
-                nteract plugins let Claude Code and Codex run exploratory Python in
-                a live notebook instead of hiding work in one-off shell commands.
-                The notebook keeps state, captures rich outputs, and stays available
-                for humans to inspect, edit, and save.
+                Plugins pin at install time. Add{" "}
+                <InlineCode>--ref vX.Y.Z</InlineCode> for a known release.
               </>
             }
-          />
+          >
+            {"/plugin marketplace add nteract/agent-plugins\n/plugin install nteract@nteract\n"}
+            <span className="text-muted-foreground"># nightly channel:</span>
+            {"\n/plugin install nightly@nteract"}
+          </InstallCard>
 
-          <div className="mx-auto mt-12 grid max-w-4xl gap-6">
-            <StepCard eyebrow="01" title="Choose the stable or nightly plugin">
-              <p>
-                Install from the generated plugin marketplace at{" "}
-                <a
-                  href="https://github.com/nteract/agent-plugins"
-                  className="font-medium text-teal-700 underline decoration-teal-700/30 underline-offset-4 hover:text-teal-900"
-                  rel="noreferrer"
-                  target="_blank"
-                >
-                  nteract/agent-plugins
-                </a>
-                . The repository is produced by the nteract release pipeline, so
-                the source of truth for changes remains the main nteract repo.
-              </p>
-              <ul className="list-disc space-y-2 pl-6">
-                <li>
-                  <strong className="text-gray-950">nteract</strong>: the stable
-                  plugin channel for normal use.
-                </li>
-                <li>
-                  <strong className="text-gray-950">nightly</strong>: early
-                  access to the latest runtime and notebook tools.
-                </li>
-              </ul>
-            </StepCard>
+          <InstallCard
+            label="Codex"
+            footnote="Restart Codex after changing plugin or marketplace settings."
+          >
+            {"codex plugin marketplace add \\\n  nteract/agent-plugins\n"}
+            <span className="text-muted-foreground">
+              {"# then run /plugin in Codex and\n# enable nteract or nightly"}
+            </span>
+          </InstallCard>
+        </div>
 
-            <StepCard eyebrow="02" title="Install in Claude Code">
-              <CommandBlock commands={claudeCommands} />
-              <p>
-                Claude Code pins plugins at install time. To install a known
-                release, add <InlineCode>--ref vX.Y.Z</InlineCode>{" "}
-                to the install command.
-              </p>
-            </StepCard>
-
-            <StepCard eyebrow="03" title="Install in Codex">
-              <CommandBlock commands={codexCommands} />
-              <p>
-                After registering the marketplace, start or restart Codex, run{" "}
-                <InlineCode>/plugin</InlineCode>,
-                pick the nteract marketplace, and enable the stable or nightly
-                plugin. Codex resolves the platform-specific sidecar bundled with
-                the plugin.
-              </p>
-            </StepCard>
-
-            <StepCard eyebrow="04" title="What agents get">
-              <ul className="list-disc space-y-2 pl-6">
-                <li>Create or connect to notebook-backed Python sessions.</li>
-                <li>Run code repeatedly while preserving variables and imports.</li>
-                <li>Add dependencies before or during exploratory work.</li>
-                <li>Inspect cells and outputs instead of reconstructing shell logs.</li>
-                <li>Save the resulting notebook when the exploration is worth keeping.</li>
-              </ul>
-              <p>
-                In practice, this gives an agent a durable scratchpad that you can
-                open in nteract, review, and continue working on yourself.
-              </p>
-            </StepCard>
-
-            <StepCard eyebrow="05" title="Troubleshooting">
-              <ul className="list-disc space-y-2 pl-6">
-                <li>
-                  If notebook tools do not appear, restart the agent after changing
-                  plugin or marketplace settings.
-                </li>
-                <li>
-                  If the stable channel is not enough, install the nightly plugin
-                  and try the same workflow there.
-                </li>
-                <li>
-                  If the agent reports runtime issues, open nteract locally and run{" "}
-                  <InlineCode>runt doctor</InlineCode>{" "}
-                  or <InlineCode>runt-nightly doctor</InlineCode>.
-                </li>
-              </ul>
-            </StepCard>
-          </div>
-
-          <div className="mx-auto mt-12 max-w-4xl rounded-3xl border border-teal-200 bg-teal-50 p-6 text-gray-800">
-            <h2 className="text-xl font-bold tracking-tight text-gray-950">
-              Want the desktop app too?
-            </h2>
-            <p className="mt-3 leading-7">
-              Install nteract from the homepage when you want the full native
-              notebook interface alongside the agent plugin. The plugin makes the
-              agent workflow available; the app gives you a friendly place to see
-              and continue the notebook work.
-            </p>
-            <Link
-              href="/"
-              className="mt-5 inline-flex rounded-full bg-gray-950 px-5 py-3 text-sm font-semibold text-white transition hover:bg-gray-800"
+        <h2 className="mb-4 text-2xl font-bold tracking-[-0.02em]">
+          What agents get
+        </h2>
+        <ul className="mb-12 flex max-w-[620px] flex-col gap-2.5">
+          {[
+            "Notebook-backed Python sessions that keep variables and imports between runs.",
+            "Dependencies added before or during exploratory work.",
+            "Cells and rich outputs to inspect instead of reconstructed shell logs.",
+            "A durable scratchpad. Save the notebook when the exploration is worth keeping.",
+          ].map((item) => (
+            <li
+              key={item}
+              className="flex gap-2.5 text-[15.5px] leading-normal"
             >
-              Download nteract
-            </Link>
-          </div>
-        </Container>
+              <span
+                aria-hidden="true"
+                className="mt-2 h-[5px] w-[5px] shrink-0 rounded-[1px] bg-foreground"
+              />
+              <span>{item}</span>
+            </li>
+          ))}
+        </ul>
+
+        <div className="flex flex-wrap items-center gap-4 border-t border-border pt-7">
+          <Link href="/install" className={buttonVariants()}>
+            Download nteract
+          </Link>
+          <span className="text-[13.5px] text-muted-foreground">
+            Tools missing? Restart the agent, or run{" "}
+            <InlineCode>runt doctor</InlineCode>.
+          </span>
+        </div>
       </main>
 
       <SiteFooter />

--- a/app/globals.css
+++ b/app/globals.css
@@ -2,14 +2,64 @@
 @import "tw-animate-css";
 @config "../tailwind.config.js";
 
+/* ──────────────────────────────────────
+   nteract Elements tokens. One neutral
+   grayscale system for the whole site;
+   chromatic color is reserved for meaning
+   (cell types, runtime state). Dark pages
+   opt in with a .dark wrapper.
+   ────────────────────────────────────── */
 :root {
-    --accent: 45 212 191; /* #2DD4BF Teal */
-    --radius: 0rem;
+    --background: oklch(1 0 0);
+    --foreground: oklch(0.145 0 0);
+    --card: oklch(1 0 0);
+    --card-foreground: oklch(0.145 0 0);
+    --primary: oklch(0.205 0 0);
+    --primary-foreground: oklch(0.985 0 0);
+    --muted: oklch(0.97 0 0);
+    --muted-foreground: oklch(0.556 0 0);
+    --border: oklch(0.922 0 0);
+    --ring: oklch(0.708 0 0);
+    --radius: 0.625rem;
+
+    /* Teal selection accent (RGB triple for rgb(var(--accent) / a)). */
+    --accent: 45 212 191;
+
+    /* Meaningful color: cell types + runtime state (from the app's
+       dashboard atoms). */
+    --ct-code: #38bdf8;
+    --ct-markdown: #34d399;
+    --ct-raw: #fb7185;
+    --live: #22c55e;
+    --k-exec: #f59e0b;
+    --k-ready: #22c55e;
+    --k-start: #3b82f6;
+    --k-stale: #9ca3af;
+    --k-error: #dc2626;
+}
+
+.dark {
+    --background: oklch(0.145 0 0);
+    --foreground: oklch(0.985 0 0);
+    --card: oklch(0.205 0 0);
+    --card-foreground: oklch(0.985 0 0);
+    --primary: oklch(0.922 0 0);
+    --primary-foreground: oklch(0.205 0 0);
+    --muted: oklch(0.269 0 0);
+    --muted-foreground: oklch(0.708 0 0);
+    --border: oklch(1 0 0 / 10%);
+    --ring: oklch(0.556 0 0);
+
+    --ct-code: #7dd3fc;
+    --ct-markdown: #6ee7b7;
+    --ct-raw: #fda4af;
+    --live: #4ade80;
+    --k-stale: #6b7280;
 }
 
 body {
     font-family:
-        var(--font-body),
+        var(--font-sans),
         system-ui,
         -apple-system,
         BlinkMacSystemFont,
@@ -29,8 +79,109 @@ body {
 }
 
 @layer components {
+    /* ──────────────────────────────────────
+       Elements atoms: notebook composition
+       ticks and the runtime status dot,
+       ported from the app's dashboard atoms.
+       ────────────────────────────────────── */
+    .nb-fp-wrap {
+        display: flex;
+        min-width: 0;
+        flex-direction: column;
+        gap: 7px;
+    }
+
+    .nb-fp {
+        display: flex;
+        align-items: stretch;
+        width: 100%;
+        max-width: 340px;
+        height: 7px;
+        overflow: hidden;
+        border-radius: 3px;
+        opacity: 0.62;
+    }
+
+    .nb-fp-seg {
+        height: 100%;
+    }
+
+    .nb-fp-seg[data-ct="code"] {
+        background: var(--ct-code);
+    }
+
+    .nb-fp-seg[data-ct="markdown"] {
+        background: var(--ct-markdown);
+    }
+
+    .nb-fp-seg[data-ct="raw"] {
+        background: var(--ct-raw);
+    }
+
+    .nb-kernel {
+        display: inline-flex;
+        align-items: center;
+        gap: 7px;
+        color: var(--muted-foreground);
+        font-family: var(--font-mono), "JetBrains Mono", monospace;
+        font-size: 11px;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        white-space: nowrap;
+    }
+
+    .nb-kdot {
+        width: 8px;
+        height: 8px;
+        flex: 0 0 auto;
+        border-radius: 50%;
+        background: var(--k-stale);
+    }
+
+    .nb-kernel[data-k="executing"] {
+        color: color-mix(in srgb, var(--k-exec) 72%, var(--foreground));
+    }
+
+    .nb-kernel[data-k="executing"] .nb-kdot {
+        background: var(--k-exec);
+    }
+
+    .nb-kernel[data-k="ready"] {
+        color: color-mix(in srgb, var(--k-ready) 60%, var(--foreground));
+    }
+
+    .nb-kernel[data-k="ready"] .nb-kdot {
+        background: var(--k-ready);
+    }
+
+    .nb-kernel[data-k="starting"] .nb-kdot {
+        background: var(--k-start);
+    }
+
+    .nb-kernel[data-k="error"] {
+        color: var(--k-error);
+    }
+
+    .nb-kernel[data-k="error"] .nb-kdot {
+        background: var(--k-error);
+    }
+
+    .nb-kernel[data-k="none"] .nb-kdot {
+        border: 1.5px solid
+            color-mix(in srgb, var(--muted-foreground) 55%, transparent);
+        background: transparent;
+    }
+
+    /* ──────────────────────────────────────
+       Prose on Elements tokens. Works on the
+       light blog surface and the Ink dark
+       changelog alike — everything routes
+       through the theme variables.
+       ────────────────────────────────────── */
     .nteract-prose {
-        @apply text-[17px] leading-8 text-gray-700;
+        font-size: 16.5px;
+        line-height: 1.7;
+        color: var(--foreground);
     }
 
     .nteract-prose > :first-child {
@@ -52,25 +203,18 @@ body {
     }
 
     .nteract-prose h2 {
-        @apply mt-12 mb-4 text-3xl font-bold tracking-tight text-gray-900;
-        font-family:
-            var(--font-headline), "Space Grotesk", system-ui, sans-serif;
+        @apply mt-12 mb-4 text-2xl font-bold tracking-[-0.02em];
+        color: var(--foreground);
     }
 
     .nteract-prose h3 {
-        @apply mt-10 mb-4 text-2xl font-bold tracking-tight text-gray-900;
-        font-family:
-            var(--font-headline), "Space Grotesk", system-ui, sans-serif;
+        @apply mt-10 mb-4 text-xl font-bold tracking-[-0.015em];
+        color: var(--foreground);
     }
 
     .nteract-prose h4 {
-        @apply mt-8 mb-3 text-xl font-bold tracking-tight text-gray-900;
-        font-family:
-            var(--font-headline), "Space Grotesk", system-ui, sans-serif;
-    }
-
-    .nteract-prose p {
-        @apply text-gray-700;
+        @apply mt-8 mb-3 text-lg font-semibold tracking-[-0.01em];
+        color: var(--foreground);
     }
 
     .nteract-prose ul,
@@ -90,12 +234,39 @@ body {
         @apply mt-2;
     }
 
+    .nteract-prose li::marker {
+        color: var(--muted-foreground);
+    }
+
     .nteract-prose strong {
-        @apply font-semibold text-gray-900;
+        @apply font-semibold;
+        color: var(--foreground);
+    }
+
+    .nteract-prose blockquote {
+        border-left: 2px solid var(--border);
+        @apply pl-5;
     }
 
     .nteract-prose blockquote p {
-        @apply text-lg text-gray-600;
+        @apply text-lg;
+        color: var(--muted-foreground);
+    }
+
+    .nteract-prose a {
+        color: var(--foreground);
+        text-decoration: underline;
+        text-underline-offset: 4px;
+        text-decoration-color: color-mix(
+            in srgb,
+            var(--foreground) 30%,
+            transparent
+        );
+        transition: text-decoration-color 150ms ease;
+    }
+
+    .nteract-prose a:hover {
+        text-decoration-color: var(--foreground);
     }
 
     .nteract-prose table {
@@ -103,11 +274,13 @@ body {
     }
 
     .nteract-prose thead {
-        @apply border-b border-black/10 text-gray-900;
+        border-bottom: 1px solid var(--border);
+        color: var(--foreground);
     }
 
     .nteract-prose tbody tr {
-        @apply border-b border-black/5;
+        border-bottom: 1px solid
+            color-mix(in srgb, var(--border) 60%, transparent);
     }
 
     .nteract-prose th,
@@ -115,21 +288,59 @@ body {
         @apply px-3 py-2;
     }
 
+    .nteract-prose img {
+        border: 1px solid var(--border);
+        border-radius: var(--radius);
+    }
+
+    .nteract-prose figcaption {
+        font-family: var(--font-mono), "JetBrains Mono", monospace;
+        font-size: 10px;
+        letter-spacing: 0.15em;
+        text-transform: uppercase;
+        color: var(--muted-foreground);
+        margin-top: 0.75rem;
+    }
+
+    /* Inline code */
+    .nteract-prose code:not([data-rehype-pretty-code-figure] code) {
+        background: var(--muted);
+        border-radius: 4px;
+        padding: 2px 6px;
+        font-size: 0.88em;
+        font-family: var(--font-mono), "JetBrains Mono", monospace;
+        color: var(--foreground);
+    }
+
+    /* Code blocks: bordered card with a mono title row */
     .nteract-prose [data-rehype-pretty-code-figure] {
-        @apply overflow-hidden border border-black/10 bg-slate-50 shadow-sm;
+        overflow: hidden;
+        border: 1px solid var(--border);
+        border-radius: var(--radius);
+        background: var(--muted);
     }
 
     .nteract-prose [data-rehype-pretty-code-title] {
-        @apply border-b border-black/10 bg-white/70 px-4 py-2 text-xs font-medium uppercase tracking-[0.3em] text-gray-500;
+        border-bottom: 1px solid var(--border);
+        padding: 8px 16px;
+        font-size: 10px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: var(--muted-foreground);
         font-family: var(--font-mono), "JetBrains Mono", monospace;
     }
 
     .nteract-prose [data-rehype-pretty-code-figure] pre {
-        @apply my-0 overflow-x-auto bg-transparent px-0 py-0 text-[14px] leading-7;
+        @apply my-0 overflow-x-auto bg-transparent;
+        padding: 16px 0;
+        font-size: 13px;
+        line-height: 1.7;
     }
 
     .nteract-prose [data-rehype-pretty-code-figure] code {
-        @apply grid min-w-full bg-transparent px-0 py-4 font-medium text-gray-800;
+        @apply grid min-w-full bg-transparent;
+        color: var(--foreground);
+        font-family: var(--font-mono), "JetBrains Mono", monospace;
         counter-reset: line;
     }
 
@@ -141,132 +352,25 @@ body {
         [data-rehype-pretty-code-figure]
         code
         [data-highlighted-line] {
-        @apply border-accent/80 bg-accent/10;
+        border-left-color: var(--ring);
+        background: color-mix(in srgb, var(--foreground) 6%, transparent);
     }
 
     .nteract-prose
         [data-rehype-pretty-code-figure]
         code
         [data-highlighted-chars] {
-        @apply rounded bg-accent/15;
+        border-radius: 4px;
+        background: color-mix(in srgb, var(--foreground) 10%, transparent);
     }
 
-    /* Dual-theme tokens: light palette on the light changelog blocks,
-       dark palette under prose-invert (the blog's black code blocks). */
+    /* Shiki dual themes keyed by surface. */
     .nteract-prose [data-rehype-pretty-code-figure] code span {
         color: var(--shiki-light);
     }
 
-    .nteract-prose.prose-invert [data-rehype-pretty-code-figure] code span {
+    .dark .nteract-prose [data-rehype-pretty-code-figure] code span {
         color: var(--shiki-dark);
-    }
-
-    /* ──────────────────────────────────────
-     Dark mode / prose-invert — Monolith
-     ────────────────────────────────────── */
-    .nteract-prose.prose-invert {
-        @apply text-[#e5e5e5]/90 leading-relaxed;
-    }
-
-    .nteract-prose.prose-invert > p:first-of-type {
-        @apply first-letter:float-left first-letter:mr-3 first-letter:text-5xl first-letter:font-bold first-letter:text-[#a993d1];
-        font-family:
-            var(--font-headline), "Space Grotesk", system-ui, sans-serif;
-    }
-
-    .nteract-prose.prose-invert h2 {
-        @apply pt-8 text-3xl font-bold text-[#e5e5e5];
-        font-family:
-            var(--font-headline), "Space Grotesk", system-ui, sans-serif;
-    }
-
-    .nteract-prose.prose-invert h3 {
-        @apply pt-6 text-2xl font-bold text-[#e5e5e5];
-        font-family:
-            var(--font-headline), "Space Grotesk", system-ui, sans-serif;
-    }
-
-    .nteract-prose.prose-invert h4 {
-        @apply pt-4 text-xl font-bold text-[#e5e5e5];
-        font-family:
-            var(--font-headline), "Space Grotesk", system-ui, sans-serif;
-    }
-
-    .nteract-prose.prose-invert p {
-        @apply text-[#e5e5e5]/90;
-    }
-
-    .nteract-prose.prose-invert strong {
-        @apply text-[#e5e5e5];
-    }
-
-    .nteract-prose.prose-invert blockquote {
-        @apply border-l-2 border-[#a993d1]/50 pl-5;
-    }
-
-    .nteract-prose.prose-invert blockquote p {
-        @apply text-[#ababab];
-    }
-
-    .nteract-prose.prose-invert thead {
-        @apply border-[#484848]/20 text-[#e5e5e5];
-    }
-
-    .nteract-prose.prose-invert tbody tr {
-        @apply border-[#484848]/10;
-    }
-
-    /* Code blocks — Monolith style: black bg, teal left rail */
-    .nteract-prose.prose-invert [data-rehype-pretty-code-figure] {
-        @apply relative -mx-6 overflow-hidden border-0 bg-[#000000] shadow-none md:-mx-24;
-    }
-
-    .nteract-prose.prose-invert [data-rehype-pretty-code-figure]::before {
-        content: "";
-        @apply absolute bottom-0 left-0 top-0 w-1 bg-[#a993d1];
-    }
-
-    .nteract-prose.prose-invert [data-rehype-pretty-code-title] {
-        @apply border-b border-[#484848]/20 bg-transparent px-8 py-3 text-[10px] uppercase tracking-widest text-[#ababab];
-        font-family: var(--font-mono), "JetBrains Mono", monospace;
-    }
-
-    .nteract-prose.prose-invert [data-rehype-pretty-code-figure] pre {
-        @apply px-8 py-6;
-    }
-
-    .nteract-prose.prose-invert [data-rehype-pretty-code-figure] code {
-        @apply text-[#e5e5e5]/90;
-        font-family: var(--font-mono), "JetBrains Mono", monospace;
-    }
-
-    .nteract-prose.prose-invert
-        [data-rehype-pretty-code-figure]
-        code
-        [data-line] {
-        @apply border-l-0 px-0;
-    }
-
-    /* Inline code */
-    .nteract-prose.prose-invert
-        code:not([data-rehype-pretty-code-figure] code) {
-        @apply bg-[#1f1f1f] px-1.5 py-0.5 text-[0.9em] text-[#a993d1];
-        font-family: var(--font-mono), "JetBrains Mono", monospace;
-    }
-
-    /* Links — secondary purple with underline */
-    .nteract-prose.prose-invert a {
-        @apply text-[#a993d1] underline decoration-[#a993d1]/30 underline-offset-4 transition-colors hover:text-[#cbb5f4] hover:decoration-[#cbb5f4]/60;
-    }
-
-    .nteract-prose.prose-invert li::marker {
-        @apply text-[#484848];
-    }
-
-    /* Images — full bleed, no rounding */
-    .nteract-prose.prose-invert > img,
-    .nteract-prose.prose-invert > p img {
-        @apply -mx-6 w-[calc(100%+3rem)] max-w-none md:-mx-24 md:w-[calc(100%+12rem)];
     }
 }
 

--- a/app/install/page.tsx
+++ b/app/install/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 
 import { DownloadButtons } from "@/components/home/download-buttons";
 import { CommandBlock, InlineCode, PageHero, StepCard } from "@/components/product/page-primitives";
-import { Container, SiteFooter, SiteHeader } from "@/components/site-shell";
+import { SiteFooter, SiteHeader } from "@/components/site-shell";
 import { siteConfig } from "@/lib/site";
 
 export const metadata: Metadata = {
@@ -27,75 +27,71 @@ async function getStableVersion(): Promise<string | null> {
 
 const INSTALL_CMD = ["curl -fsSL https://sh.nteract.io | bash"];
 
+const linkClassName =
+  "font-medium text-foreground underline decoration-[color-mix(in_srgb,var(--foreground)_30%,transparent)] underline-offset-4 transition-colors hover:decoration-[var(--foreground)]";
+
 export default async function InstallPage() {
   const version = await getStableVersion();
 
   return (
-    <div className="min-h-screen bg-gray-50 text-gray-900">
-      <SiteHeader />
+    <div className="flex min-h-screen flex-col bg-background text-foreground">
+      <SiteHeader active="install" />
 
-      <main>
-        <Container className="py-16 sm:py-24">
-          <PageHero
-            eyebrow="Install"
-            title="Install nteract"
-            subtitle={
-              <>
-                The desktop app for the machine in front of you. One command for
-                every other machine you own.
-              </>
-            }
-          />
+      <main className="mx-auto w-full max-w-[47.5rem] flex-1 px-6 pb-[72px] pt-16 sm:px-10">
+        <PageHero
+          eyebrow="Install"
+          detail="macos · windows · linux"
+          title="Install nteract"
+          subtitle={
+            <>
+              The desktop app for the machine in front of you. One command for
+              every other machine you own.
+            </>
+          }
+        />
 
-          <div className="mx-auto mt-12 grid max-w-4xl gap-6">
-            <StepCard eyebrow="01" title="Desktop app">
-              <p>
-                macOS (Apple silicon or Intel), Windows, and Linux. The app
-                bundles everything: the notebook, the <InlineCode>runt</InlineCode>{" "}
-                CLI, and the <InlineCode>runtimed</InlineCode> daemon, kept up to
-                date automatically.
-              </p>
-              <DownloadButtons version={version} />
-            </StepCard>
+        <div className="grid gap-5">
+          <StepCard eyebrow="Desktop" title="Desktop app">
+            <p>
+              macOS (Apple silicon or Intel), Windows, and Linux. The app
+              bundles everything: the notebook, the <InlineCode>runt</InlineCode>{" "}
+              CLI, and the <InlineCode>runtimed</InlineCode> daemon, kept up to
+              date automatically.
+            </p>
+            <DownloadButtons version={version} />
+          </StepCard>
 
-            <StepCard eyebrow="02" title="One command — Linux & macOS">
-              <CommandBlock commands={INSTALL_CMD} />
-              <p>
-                Installs the app (the AppImage on Linux; the signed bundle in{" "}
-                <InlineCode>~/Applications</InlineCode> on macOS) plus{" "}
-                <InlineCode>runt</InlineCode>, <InlineCode>runtimed</InlineCode>,
-                and <InlineCode>nteract-mcp</InlineCode>, links the commands
-                into <InlineCode>~/.local/bin</InlineCode>, and sets up the
-                per-user daemon service (systemd on Linux, launchd on macOS).
-                Everything is per-user — no root, no system package manager.
-                Re-run the same command to upgrade.
-              </p>
-            </StepCard>
+          <StepCard eyebrow="Headless" title="One command — Linux & macOS">
+            <CommandBlock commands={INSTALL_CMD} />
+            <p>
+              Installs the app (the AppImage on Linux; the signed bundle in{" "}
+              <InlineCode>~/Applications</InlineCode> on macOS) plus{" "}
+              <InlineCode>runt</InlineCode>, <InlineCode>runtimed</InlineCode>,
+              and <InlineCode>nteract-mcp</InlineCode>, links the commands
+              into <InlineCode>~/.local/bin</InlineCode>, and sets up the
+              per-user daemon service (systemd on Linux, launchd on macOS).
+              Everything is per-user — no root, no system package manager.
+              Re-run the same command to upgrade.
+            </p>
+          </StepCard>
 
-            <StepCard eyebrow="03" title="Channels">
-              <p>
-                Stable is the default everywhere above. The{" "}
-                <Link
-                  href="/nightly"
-                  className="font-medium text-teal-700 underline decoration-teal-700/30 underline-offset-4 hover:text-teal-900"
-                >
-                  nightly channel
-                </Link>{" "}
-                installs side-by-side with channel-suffixed commands
-                (<InlineCode>runt-nightly</InlineCode>,{" "}
-                <InlineCode>nteract-nightly</InlineCode>), so you can run both.
-                Agents have their own setup — see{" "}
-                <Link
-                  href="/agents"
-                  className="font-medium text-teal-700 underline decoration-teal-700/30 underline-offset-4 hover:text-teal-900"
-                >
-                  nteract for agents
-                </Link>
-                .
-              </p>
-            </StepCard>
-          </div>
-        </Container>
+          <StepCard eyebrow="Channels" title="Channels">
+            <p>
+              Stable is the default everywhere above. The{" "}
+              <Link href="/nightly" className={linkClassName}>
+                nightly channel
+              </Link>{" "}
+              installs side-by-side with channel-suffixed commands
+              (<InlineCode>runt-nightly</InlineCode>,{" "}
+              <InlineCode>nteract-nightly</InlineCode>), so you can run both.
+              Agents have their own setup — see{" "}
+              <Link href="/agents" className={linkClassName}>
+                nteract for agents
+              </Link>
+              .
+            </p>
+          </StepCard>
+        </div>
       </main>
 
       <SiteFooter />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -75,7 +75,7 @@ export default function RootLayout({
   return (
     <html lang="en" className={cn("font-sans", geist.variable)}>
       <body
-        className={`${spaceGrotesk.variable} ${inter.variable} ${jetbrainsMono.variable} ${sourceSerif.variable} min-h-screen font-body antialiased`}
+        className={`${spaceGrotesk.variable} ${inter.variable} ${jetbrainsMono.variable} ${sourceSerif.variable} min-h-screen antialiased`}
       >
         {children}
         <Analytics />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 
 import { Logo } from "@/components/logo";
 import { DownloadButtons } from "@/components/home/download-buttons";
+import { RuntimeStatusDot } from "@/components/elements/runtime-status-dot";
 import { SiteFooter, SiteHeader } from "@/components/site-shell";
 import { getAllEntries } from "@/lib/changelog";
 import { siteConfig } from "@/lib/site";
@@ -24,34 +25,32 @@ export default async function Home() {
   const [latestEntry] = await getAllEntries({ includeUnpublished: false });
 
   return (
-    <div className="flex min-h-screen flex-col">
-      <SiteHeader variant="floating" />
+    <div className="flex min-h-screen flex-col bg-background text-foreground">
+      <SiteHeader />
       <main className="flex flex-1 flex-col items-center justify-center px-4 py-16">
-        <div className="max-w-2xl mx-auto text-center">
+        <div className="mx-auto max-w-2xl text-center">
           <Link
             href={latestEntry ? `/changelog/${latestEntry.version}` : "/changelog"}
-            className="group mb-10 inline-flex items-center gap-2 rounded-full border border-gray-200 bg-white py-1 pl-1.5 pr-4 text-sm shadow-sm transition hover:border-gray-300 hover:shadow"
+            className="group mb-10 inline-flex items-center gap-2.5 rounded-full border border-border bg-card py-1.5 pl-4 pr-4 text-sm transition-colors hover:border-ring"
           >
-            <span className="rounded-full bg-accent px-2.5 py-0.5 text-xs font-semibold text-white">
-              New
-            </span>
-            <span className="font-medium text-gray-700 transition-colors group-hover:text-gray-900">
+            <RuntimeStatusDot status="ready" />
+            <span className="font-medium text-foreground">
               {latestEntry ? `nteract ${latestEntry.version} is out` : "See what's new"}
             </span>
-            <span className="text-gray-400 transition-transform group-hover:translate-x-0.5">
+            <span className="text-muted-foreground transition-transform group-hover:translate-x-0.5">
               →
             </span>
           </Link>
 
-          <Logo className="w-40 h-40 mx-auto mb-8" />
+          <Logo className="mx-auto mb-8 h-40 w-40" />
 
-          <p className="text-sm uppercase tracking-widest text-gray-400 mb-2">
+          <p className="mb-3 font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
             Native interactive notebooks
           </p>
-          <h1 className="text-5xl font-bold text-gray-900 mb-3">
+          <h1 className="mb-3 text-5xl font-bold tracking-[-0.03em]">
             {siteConfig.name}
           </h1>
-          <p className="text-base text-gray-500 mb-8 max-w-md mx-auto">
+          <p className="mx-auto mb-8 max-w-md text-base text-muted-foreground">
             Fast to launch. Agent ready. Humans welcome.
           </p>
 
@@ -60,11 +59,10 @@ export default async function Home() {
           <div className="mt-12">
             <Link
               href="/agents"
-              className="group inline-flex items-center gap-2 text-sm text-gray-500 transition-colors hover:text-gray-900"
+              className="group inline-flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
             >
-              <span className="text-base">🤖</span>
               <span>
-                <span className="font-medium text-gray-700 group-hover:text-gray-900">
+                <span className="font-medium text-foreground">
                   Using agents?
                 </span>{" "}
                 Install the plugins

--- a/components/blog/author-byline.tsx
+++ b/components/blog/author-byline.tsx
@@ -7,9 +7,10 @@ type BlogAuthorBylineProps = {
   className?: string;
 };
 
+/** Author names for the mono meta rows ("April 7, 2026 · Kyle Kelley"). */
 export function BlogAuthorByline({
   authors,
-  className = "font-mono text-xs text-secondary",
+  className,
 }: BlogAuthorBylineProps) {
   if (authors.length === 0) {
     return null;
@@ -17,13 +18,12 @@ export function BlogAuthorByline({
 
   return (
     <span className={className}>
-      By{" "}
       {authors.map((author, index) => (
         <Fragment key={author.id}>
           {index > 0 ? (index === authors.length - 1 ? " and " : ", ") : null}
           <a
             href={author.url}
-            className="transition-colors hover:text-on-surface"
+            className="transition-colors hover:text-foreground"
           >
             {author.name}
           </a>

--- a/components/blog/cta.tsx
+++ b/components/blog/cta.tsx
@@ -2,6 +2,9 @@
 
 import { useEffect, useMemo, useState } from "react";
 
+import { buttonVariants } from "@/components/ui/button-variants";
+import { cn } from "@/lib/utils";
+
 type Platform = "macOS" | "Windows" | "Linux";
 
 function detectPlatform(): Platform {
@@ -45,12 +48,11 @@ export function BlogCTA() {
       : `Download for ${platform}`;
 
   return (
-    <div className="not-prose mt-16 flex flex-wrap items-center gap-4">
+    <div className="not-prose mt-16 flex flex-wrap items-center gap-3">
       <a
         href={href}
         {...(platform === "Windows" ? { target: "_blank", rel: "noopener noreferrer" } : {})}
-        className="inline-flex items-center gap-2 bg-[#a993d1] px-8 py-4 font-headline font-bold transition-all hover:bg-[#cbb5f4] no-underline"
-        style={{ color: "#0e0e0e" }}
+        className={cn(buttonVariants({ size: "lg" }), "no-underline")}
       >
         {label}
       </a>
@@ -58,8 +60,10 @@ export function BlogCTA() {
         href="https://github.com/nteract/nteract"
         target="_blank"
         rel="noopener noreferrer"
-        className="inline-flex items-center gap-2 border border-[#484848] px-8 py-4 font-headline font-bold transition-colors hover:bg-[#131313] no-underline"
-        style={{ color: "#e5e5e5" }}
+        className={cn(
+          buttonVariants({ variant: "outline", size: "lg" }),
+          "no-underline",
+        )}
       >
         <svg className="h-5 w-5" viewBox="0 0 24 24" fill="currentColor">
           <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />

--- a/components/blog/inline-cta.tsx
+++ b/components/blog/inline-cta.tsx
@@ -13,14 +13,14 @@ export function BlogInlineCTA({ href, children, lead }: BlogInlineCTAProps) {
     href.startsWith("http://") || href.startsWith("https://");
 
   return (
-    <div className="not-prose font-body text-[0.95rem] leading-relaxed text-on-surface-variant/75">
+    <div className="not-prose text-[0.95rem] leading-relaxed text-muted-foreground">
       {lead ? <span>{lead} </span> : null}
       <a
         href={href}
         {...(isExternal
           ? { target: "_blank", rel: "noopener noreferrer" }
           : {})}
-        className="group inline-flex items-baseline gap-1.5 text-[#cbb5f4] underline decoration-[#a993d1]/40 decoration-from-font underline-offset-[5px] transition-colors hover:decoration-[#cbb5f4]"
+        className="group inline-flex items-baseline gap-1.5 text-foreground underline decoration-[color-mix(in_srgb,var(--foreground)_30%,transparent)] decoration-from-font underline-offset-[5px] transition-colors hover:decoration-[var(--foreground)]"
       >
         {children}
         <span

--- a/components/blog/post-card.tsx
+++ b/components/blog/post-card.tsx
@@ -1,7 +1,6 @@
 import Link from "next/link";
 
-import { BlogAuthorByline } from "@/components/blog/author-byline";
-import { BlogTagList } from "@/components/blog/tag-list";
+import { NotebookCompositionTicks } from "@/components/elements/notebook-composition-ticks";
 import { formatPostDate, type BlogPostSummary } from "@/lib/blog";
 
 type BlogPostCardProps = {
@@ -10,47 +9,23 @@ type BlogPostCardProps = {
 
 export function BlogPostCard({ post }: BlogPostCardProps) {
   return (
-    <article className="group relative bg-surface-container-low p-6 pl-8 transition-all hover:bg-surface-container">
-      {/* Teal rail accent on hover */}
-      <div className="absolute bottom-6 left-0 top-6 w-1 bg-transparent transition-all group-hover:bg-tertiary" />
-
-      <div className="mb-4 flex flex-wrap items-center gap-3">
-        <time
-          dateTime={post.date}
-          className="font-mono text-[11px] uppercase tracking-widest text-secondary"
-        >
-          {formatPostDate(post.date)}
-        </time>
-        {post.authors.length > 0 ? (
-          <>
-            <span className="h-1 w-1 bg-outline-variant" aria-hidden="true" />
-            <BlogAuthorByline
-              authors={post.authors}
-              className="font-mono text-[11px] text-secondary"
-            />
-          </>
-        ) : null}
-        {post.tags.length > 0 ? (
-          <span
-            className="h-1 w-1 bg-outline-variant"
-            aria-hidden="true"
-          />
-        ) : null}
-        <BlogTagList tags={post.tags} />
+    <Link
+      href={`/blog/${post.slug}`}
+      className="flex flex-col gap-1.5 rounded-lg border border-border bg-card p-5 px-[22px] transition-colors hover:border-ring"
+    >
+      <div className="flex items-center gap-2.5 font-mono text-[11px] uppercase tracking-[0.1em] text-muted-foreground">
+        <time dateTime={post.date}>{formatPostDate(post.date)}</time>
+        <NotebookCompositionTicks
+          composition={post.composition}
+          className="w-[60px]"
+        />
       </div>
-
-      <h2 className="font-headline text-2xl font-bold tracking-tight text-on-surface">
-        <Link
-          href={`/blog/${post.slug}`}
-          className="transition-colors group-hover:text-primary"
-        >
-          {post.title}
-        </Link>
-      </h2>
-
-      <p className="mt-3 text-base leading-7 text-on-surface-variant">
+      <span className="text-lg font-semibold tracking-[-0.01em] text-foreground">
+        {post.title}
+      </span>
+      <span className="text-[15px] leading-[1.55] text-muted-foreground">
         {post.description}
-      </p>
-    </article>
+      </span>
+    </Link>
   );
 }

--- a/components/blog/tag-list.tsx
+++ b/components/blog/tag-list.tsx
@@ -11,10 +11,10 @@ export function BlogTagList({ tags, className }: BlogTagListProps) {
   }
 
   return (
-    <ul className={cn("flex flex-wrap gap-3", className)}>
+    <ul className={cn("flex flex-wrap gap-2.5", className)}>
       {tags.map((tag) => (
         <li key={tag}>
-          <span className="inline-flex items-center bg-surface-container-high px-3 py-1 font-mono text-[11px] uppercase tracking-wider text-on-surface-variant">
+          <span className="inline-flex items-center bg-muted px-3 py-1 font-mono text-[11px] uppercase tracking-[0.05em] text-muted-foreground">
             {tag}
           </span>
         </li>

--- a/components/changelog/changelog-feed-entry.tsx
+++ b/components/changelog/changelog-feed-entry.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import Link from "next/link";
 
 import { ChangelogTagList } from "@/components/changelog/tag-list";
+import { RuntimeStatusDot } from "@/components/elements/runtime-status-dot";
 import { Prose } from "@/components/prose";
 import { formatEntryDate, type ChangelogEntrySummary } from "@/lib/changelog";
 
@@ -13,10 +14,11 @@ type ChangelogFeedEntryProps = {
 };
 
 /**
- * One release rendered in full inline in the scrolling feed: version + date in
- * a left rail, the whole story on the right (highlights, hero, and the MDX
- * body, whose exhaustive technical changelog stays inside its collapsed
- * disclosure). The version and date link to the shareable per-version page.
+ * One release rendered in full inline in the scrolling feed: version, shipped
+ * state, and date in a left rail, the whole story on the right (highlights,
+ * hero, and the MDX body, whose exhaustive technical changelog stays inside
+ * its collapsed disclosure). The version and title link to the shareable
+ * per-version page.
  */
 export function ChangelogFeedEntry({ entry, children }: ChangelogFeedEntryProps) {
   const href = `/changelog/${entry.version}`;
@@ -24,84 +26,88 @@ export function ChangelogFeedEntry({ entry, children }: ChangelogFeedEntryProps)
   return (
     <article
       id={`v${entry.version}`}
-      className="scroll-mt-24 border-t border-[var(--rule)] pt-12"
+      className="scroll-mt-24 border-t border-border py-9 md:grid md:grid-cols-[140px_1fr] md:gap-7"
     >
-      <div className="grid gap-6 md:grid-cols-[180px_1fr] md:gap-10">
-        {/* Left rail — version + date */}
-        <div className="flex flex-row items-baseline gap-4 md:flex-col md:items-start md:gap-3">
+      {/* Left rail — version + release state + date */}
+      <div className="mb-5 flex flex-row items-baseline gap-4 md:mb-0 md:flex-col md:items-start md:gap-2">
+        <Link
+          href={href}
+          className="font-mono text-[32px] font-semibold tracking-[-0.02em] text-foreground transition-colors hover:text-muted-foreground"
+        >
+          {entry.version}
+        </Link>
+        <RuntimeStatusDot
+          status={entry.published ? "ready" : "executing"}
+          showLabel
+          label={entry.published ? "shipped" : "in progress"}
+        />
+        <time
+          dateTime={entry.date}
+          className="font-mono text-[11px] uppercase tracking-[0.1em] text-muted-foreground"
+        >
+          {formatEntryDate(entry)}
+        </time>
+      </div>
+
+      {/* Content */}
+      <div className="flex flex-col gap-3">
+        <Link href={href} className="block">
+          <h2 className="text-2xl font-bold tracking-[-0.02em] text-foreground">
+            {entry.title}
+          </h2>
+        </Link>
+
+        <p className="text-[15px] leading-[1.55] text-muted-foreground">
+          {entry.summary}
+        </p>
+
+        {entry.highlights.length > 0 ? (
+          <ul className="mt-1 flex flex-col gap-[7px]">
+            {entry.highlights.map((highlight) => (
+              <li
+                key={highlight}
+                className="flex gap-2.5 text-[14.5px] leading-[1.45] text-foreground"
+              >
+                <span
+                  aria-hidden="true"
+                  className="mt-[7px] h-[5px] w-[5px] shrink-0 rounded-[1px] bg-foreground"
+                />
+                <span>{highlight}</span>
+              </li>
+            ))}
+          </ul>
+        ) : null}
+
+        {/* Hero — driven by heroVideo / heroImage frontmatter */}
+        {entry.heroVideo ? (
+          <div className="mt-2 overflow-hidden rounded-lg border border-border">
+            <video
+              src={entry.heroVideo}
+              poster={entry.heroVideoPoster}
+              autoPlay
+              muted
+              loop
+              playsInline
+              className="block w-full"
+            />
+          </div>
+        ) : entry.heroImage ? (
+          <div className="mt-2 overflow-hidden rounded-lg border border-border">
+            <img src={entry.heroImage} alt={entry.title} className="block w-full" />
+          </div>
+        ) : null}
+
+        {/* Full body, rendered inline */}
+        {children ? <Prose className="mt-2">{children}</Prose> : null}
+
+        <div className="mt-3 flex flex-wrap items-center gap-5">
+          <ChangelogTagList tags={entry.tags} />
           <Link
             href={href}
-            className="font-mono text-4xl font-semibold tracking-tight text-[var(--ink)] transition-colors hover:text-[var(--accent)] md:text-5xl"
+            className="font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground transition-colors hover:text-foreground"
           >
-            {entry.version}
+            Permalink →
           </Link>
-          <time
-            dateTime={entry.date}
-            className="font-mono text-[11px] uppercase tracking-widest text-[var(--accent)]"
-          >
-            {formatEntryDate(entry)}
-          </time>
-        </div>
-
-        {/* Content */}
-        <div>
-          <Link href={href} className="group block">
-            <h2 className="mb-3 text-3xl font-normal leading-[1.1] text-[var(--ink)] transition-colors group-hover:text-[var(--accent)] md:text-4xl">
-              {entry.title}
-            </h2>
-          </Link>
-
-          <p className="mb-6 max-w-2xl text-lg leading-snug text-[var(--muted)]">
-            {entry.summary}
-          </p>
-
-          {entry.highlights.length > 0 ? (
-            <ul className="mb-6 space-y-2">
-              {entry.highlights.map((highlight) => (
-                <li key={highlight} className="flex gap-3 text-[var(--ink)]">
-                  <span
-                    aria-hidden="true"
-                    className="mt-[0.55rem] h-1.5 w-1.5 shrink-0 bg-[var(--accent)]"
-                  />
-                  <span className="leading-snug">{highlight}</span>
-                </li>
-              ))}
-            </ul>
-          ) : null}
-
-          {/* Hero — driven by heroVideo / heroImage frontmatter */}
-          {entry.heroVideo ? (
-            <div className="mb-6 overflow-hidden border border-[var(--rule)]">
-              <video
-                src={entry.heroVideo}
-                poster={entry.heroVideoPoster}
-                autoPlay
-                muted
-                loop
-                playsInline
-                className="w-full"
-              />
-            </div>
-          ) : entry.heroImage ? (
-            <div className="mb-6 overflow-hidden border border-[var(--rule)]">
-              <img src={entry.heroImage} alt={entry.title} className="w-full" />
-            </div>
-          ) : null}
-
-          {/* Full body, rendered inline */}
-          {children ? (
-            <Prose className="nteract-prose max-w-2xl">{children}</Prose>
-          ) : null}
-
-          <div className="mt-8 flex flex-wrap items-center gap-6">
-            <ChangelogTagList tags={entry.tags} />
-            <Link
-              href={href}
-              className="font-mono text-[11px] uppercase tracking-widest text-[var(--accent)] transition-colors hover:text-[var(--ink)]"
-            >
-              Permalink →
-            </Link>
-          </div>
         </div>
       </div>
     </article>

--- a/components/changelog/tag-list.tsx
+++ b/components/changelog/tag-list.tsx
@@ -5,7 +5,6 @@ type ChangelogTagListProps = {
   className?: string;
 };
 
-/** Outlined cream-theme tags (the dark blog uses filled chips instead). */
 export function ChangelogTagList({ tags, className }: ChangelogTagListProps) {
   if (!tags.length) {
     return null;
@@ -15,7 +14,7 @@ export function ChangelogTagList({ tags, className }: ChangelogTagListProps) {
     <ul className={cn("flex flex-wrap gap-2", className)}>
       {tags.map((tag) => (
         <li key={tag}>
-          <span className="inline-flex items-center border border-[var(--rule)] px-2.5 py-1 font-mono text-[11px] uppercase tracking-wider text-[var(--muted)]">
+          <span className="inline-flex items-center bg-muted px-3 py-1 font-mono text-[11px] uppercase tracking-[0.05em] text-muted-foreground">
             {tag}
           </span>
         </li>

--- a/components/elements/notebook-composition-ticks.tsx
+++ b/components/elements/notebook-composition-ticks.tsx
@@ -1,0 +1,128 @@
+import type { CSSProperties } from "react";
+
+export interface NotebookComposition {
+  code: number;
+  markdown: number;
+  raw: number;
+}
+
+export interface NotebookCompositionTicksProps {
+  composition: NotebookComposition;
+  maxTicks?: number;
+  className?: string;
+}
+
+type NotebookCellType = keyof NotebookComposition;
+
+const CELL_TYPES: NotebookCellType[] = ["code", "markdown", "raw"];
+const CELL_LABEL: Record<NotebookCellType, string> = {
+  code: "Code",
+  markdown: "Markdown",
+  raw: "Raw",
+};
+
+/**
+ * Ported from the app (src/components/notebook/NotebookCompositionTicks.tsx):
+ * cell-type composition as capped visual state. The site uses it as a
+ * fingerprint of a post's code/markdown balance.
+ */
+export function NotebookCompositionTicks({
+  composition,
+  maxTicks = 40,
+  className,
+}: NotebookCompositionTicksProps) {
+  const sequence = notebookCellSequence(composition, maxTicks);
+  const runs = notebookCellRuns(sequence);
+  // Only present types read out — "0 Raw" is noise for a screen reader.
+  const label = CELL_TYPES.filter((type) => (composition[type] || 0) > 0)
+    .map((type) => `${composition[type]} ${CELL_LABEL[type]}`)
+    .join(", ");
+
+  return (
+    <div className={["nb-fp-wrap", className].filter(Boolean).join(" ")}>
+      <div className="nb-fp" role="img" aria-label={label}>
+        {runs.map((run, index) => (
+          <span
+            key={`${run.type}-${index}`}
+            className="nb-fp-seg"
+            data-ct={run.type}
+            style={
+              {
+                flexBasis: 0,
+                flexGrow: run.count,
+              } satisfies CSSProperties
+            }
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function notebookCellSequence(
+  composition: NotebookComposition,
+  maxTicks: number,
+): NotebookCellType[] {
+  const total = CELL_TYPES.reduce(
+    (sum, type) => sum + (composition[type] || 0),
+    0,
+  );
+  const cap = Math.max(0, Math.floor(maxTicks));
+  if (!total || !cap) {
+    return [];
+  }
+
+  const scale = total > cap ? cap / total : 1;
+  const counts = new Map<NotebookCellType, number>();
+  let scaledTotal = 0;
+  for (const type of CELL_TYPES) {
+    const count = Math.round((composition[type] || 0) * scale);
+    if (count > 0) {
+      counts.set(type, count);
+      scaledTotal += count;
+    }
+  }
+
+  const assigned = new Map<NotebookCellType, number>();
+  for (const type of counts.keys()) {
+    assigned.set(type, 0);
+  }
+
+  const sequence: NotebookCellType[] = [];
+  for (let index = 0; index < scaledTotal; index += 1) {
+    let bestType: NotebookCellType | null = null;
+    let bestRatio = Infinity;
+    for (const [type, count] of counts) {
+      const current = assigned.get(type) ?? 0;
+      if (current >= count) {
+        continue;
+      }
+      const ratio = current / count;
+      if (ratio < bestRatio) {
+        bestRatio = ratio;
+        bestType = type;
+      }
+    }
+    if (!bestType) {
+      break;
+    }
+    sequence.push(bestType);
+    assigned.set(bestType, (assigned.get(bestType) ?? 0) + 1);
+  }
+  return sequence;
+}
+
+function notebookCellRuns(
+  sequence: NotebookCellType[],
+): { type: NotebookCellType; count: number }[] {
+  const runs: { type: NotebookCellType; count: number }[] = [];
+  for (const type of sequence) {
+    const last = runs.at(-1);
+    if (last?.type === type) {
+      last.count += 1;
+    } else {
+      runs.push({ type, count: 1 });
+    }
+  }
+  return runs;
+}

--- a/components/elements/runtime-status-dot.tsx
+++ b/components/elements/runtime-status-dot.tsx
@@ -1,0 +1,47 @@
+export type RuntimeStatus =
+  | "executing"
+  | "ready"
+  | "starting"
+  | "stale"
+  | "error"
+  | "none";
+
+export interface RuntimeStatusDotProps {
+  status: RuntimeStatus;
+  label?: string;
+  showLabel?: boolean;
+  className?: string;
+}
+
+const RUNTIME_STATUS_LABELS: Record<RuntimeStatus, string> = {
+  executing: "Running",
+  ready: "Kernel ready",
+  starting: "Connecting",
+  stale: "Disconnected",
+  error: "Runtime error",
+  none: "No compute",
+};
+
+/**
+ * Ported from the app (src/components/runtime/RuntimeStatusDot.tsx): the
+ * current runtime state as a calm status marker. On the site it doubles as
+ * release state ("shipped") in the changelog rails.
+ */
+export function RuntimeStatusDot({
+  status,
+  label,
+  showLabel = false,
+  className,
+}: RuntimeStatusDotProps) {
+  const displayLabel = label ?? RUNTIME_STATUS_LABELS[status];
+  return (
+    <span
+      className={["nb-kernel", className].filter(Boolean).join(" ")}
+      data-k={status}
+      aria-label={displayLabel}
+    >
+      <i className="nb-kdot" aria-hidden="true" />
+      {showLabel ? displayLabel : null}
+    </span>
+  );
+}

--- a/components/home/download-buttons.tsx
+++ b/components/home/download-buttons.tsx
@@ -175,9 +175,9 @@ export function DownloadButtons({ version }: { version: string | null }) {
         <a
           href={primaryUrl}
           className={cn(
-            "inline-flex items-center gap-3 rounded-lg px-8 py-4",
-            "bg-accent/90 text-lg font-medium text-white shadow-lg transition-all",
-            "hover:-translate-y-0.5 hover:bg-accent hover:shadow-xl",
+            "inline-flex items-center gap-3 rounded-lg px-7 py-3.5",
+            "bg-primary text-base font-medium text-primary-foreground transition-colors",
+            "hover:bg-[color-mix(in_srgb,var(--primary)_88%,var(--background))]",
           )}
         >
           {primary.icon}
@@ -195,7 +195,7 @@ export function DownloadButtons({ version }: { version: string | null }) {
             <a
               key={key}
               href={href}
-              className="inline-flex items-center gap-2 rounded-full px-3 py-2 text-sm text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-900"
+              className="inline-flex items-center gap-2 rounded-full px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
             >
               {meta.icon}
               {meta.shortLabel}

--- a/components/mdx-components.tsx
+++ b/components/mdx-components.tsx
@@ -60,7 +60,7 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
     h2: ({ className, ...props }) => (
       <h2
         className={cn(
-          "scroll-mt-24 font-headline text-3xl font-bold tracking-tight",
+          "scroll-mt-24 text-2xl font-bold tracking-[-0.02em]",
           className,
         )}
         {...props}
@@ -69,7 +69,7 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
     h3: ({ className, ...props }) => (
       <h3
         className={cn(
-          "scroll-mt-24 font-headline text-2xl font-bold tracking-tight",
+          "scroll-mt-24 text-xl font-bold tracking-[-0.015em]",
           className,
         )}
         {...props}
@@ -78,7 +78,7 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
     h4: ({ className, ...props }) => (
       <h4
         className={cn(
-          "scroll-mt-24 font-headline text-xl font-bold tracking-tight",
+          "scroll-mt-24 text-lg font-semibold tracking-[-0.01em]",
           className,
         )}
         {...props}
@@ -111,7 +111,7 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
       <blockquote className={cn("pl-5", className)} {...props} />
     ),
     hr: ({ className, ...props }) => (
-      <hr className={cn("border-outline-variant/20", className)} {...props} />
+      <hr className={cn("border-border", className)} {...props} />
     ),
     BlogCTA,
     BlogInlineCTA,

--- a/components/product/page-primitives.tsx
+++ b/components/product/page-primitives.tsx
@@ -3,10 +3,8 @@ import type { ReactNode } from "react";
 import { cn } from "@/lib/utils";
 
 /**
- * Eyebrow label for product pages (install, agents, docs). One convention
- * so the product pages stop drifting between tracking-widest, tracking-[0.25em],
- * and tracking-[0.3em]. Uses teal-600 as the text accent (readable on the
- * bg-gray-50 product surface); the --accent token stays for fills.
+ * Eyebrow label for product pages: the mono ledger label (11px uppercase,
+ * wide tracking) shared with the site header and the blog/changelog meta rows.
  */
 export function ProductEyebrow({
   children,
@@ -18,7 +16,7 @@ export function ProductEyebrow({
   return (
     <p
       className={cn(
-        "text-sm font-semibold uppercase tracking-[0.3em] text-teal-600",
+        "font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground",
         className,
       )}
     >
@@ -28,25 +26,32 @@ export function ProductEyebrow({
 }
 
 /**
- * Centered hero block for product pages: eyebrow + h1 + subtitle. Install
- * and agents share this exact shape; home can adopt it too.
+ * Ledger hero for product pages: mono meta row (label · rule · detail), a big
+ * tight headline, and a muted subtitle. The agents page and install share
+ * this shape.
  */
 export function PageHero({
   eyebrow,
+  detail,
   title,
   subtitle,
 }: {
   eyebrow: string;
+  detail?: string;
   title: ReactNode;
   subtitle: ReactNode;
 }) {
   return (
-    <div className="mx-auto max-w-3xl text-center">
-      <ProductEyebrow className="mb-4">{eyebrow}</ProductEyebrow>
-      <h1 className="text-4xl font-bold tracking-tight text-gray-950 sm:text-6xl">
+    <div>
+      <div className="mb-7 flex items-center gap-3 font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
+        <span>{eyebrow}</span>
+        <div className="h-px flex-grow bg-border" />
+        {detail ? <span>{detail}</span> : null}
+      </div>
+      <h1 className="mb-4 text-[40px] font-extrabold leading-[0.98] tracking-[-0.04em] text-foreground sm:text-[56px]">
         {title}
       </h1>
-      <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-gray-600">
+      <p className="mb-12 max-w-[600px] text-lg leading-[1.55] text-muted-foreground">
         {subtitle}
       </p>
     </div>
@@ -54,8 +59,8 @@ export function PageHero({
 }
 
 /**
- * Numbered step card for install/agents flows: eyebrow (usually "01", "02"...)
- * + title + body. The rounded-3xl white card on the gray-50 product surface.
+ * Titled card for install/agents flows: mono eyebrow + title + body on the
+ * bordered card surface.
  */
 export function StepCard({
   eyebrow,
@@ -67,14 +72,14 @@ export function StepCard({
   children: ReactNode;
 }) {
   return (
-    <section className="rounded-3xl border border-black/10 bg-white p-6 shadow-sm">
-      <p className="mb-3 text-xs font-semibold uppercase tracking-[0.25em] text-teal-600">
+    <section className="rounded-lg border border-border bg-card p-6">
+      <p className="mb-3 font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
         {eyebrow}
       </p>
-      <h2 className="mb-4 text-2xl font-bold tracking-tight text-gray-950">
+      <h2 className="mb-4 text-2xl font-bold tracking-[-0.02em] text-foreground">
         {title}
       </h2>
-      <div className="space-y-4 text-[16px] leading-7 text-gray-700">
+      <div className="space-y-4 text-[15.5px] leading-7 text-foreground">
         {children}
       </div>
     </section>
@@ -82,11 +87,12 @@ export function StepCard({
 }
 
 /**
- * Dark command block for shell commands. Slate-950 bg, slate-100 text.
+ * Dark command block for shell commands. Ink surface regardless of the page
+ * theme, matching the design's install cards.
  */
 export function CommandBlock({ commands }: { commands: string[] }) {
   return (
-    <pre className="overflow-x-auto rounded-2xl border border-black/10 bg-slate-950 px-5 py-4 text-sm leading-7 text-slate-100 shadow-sm">
+    <pre className="overflow-x-auto rounded-lg border border-border bg-[oklch(0.13_0_0)] p-4 font-mono text-[12.5px] leading-[1.8] text-[oklch(0.93_0_0)]">
       <code>{commands.join("\n")}</code>
     </pre>
   );
@@ -97,6 +103,8 @@ export function CommandBlock({ commands }: { commands: string[] }) {
  */
 export function InlineCode({ children }: { children: ReactNode }) {
   return (
-    <code className="rounded bg-gray-100 px-1 py-0.5">{children}</code>
+    <code className="rounded bg-muted px-1.5 py-px font-mono text-[0.9em]">
+      {children}
+    </code>
   );
 }

--- a/components/site-shell.tsx
+++ b/components/site-shell.tsx
@@ -6,7 +6,6 @@ import { siteConfig } from "@/lib/site";
 import { cn } from "@/lib/utils";
 
 type ContainerProps = HTMLAttributes<HTMLDivElement>;
-type HeaderVariant = "light" | "dark" | "floating";
 
 export function Container({ className, ...props }: ContainerProps) {
   return (
@@ -17,162 +16,120 @@ export function Container({ className, ...props }: ContainerProps) {
   );
 }
 
+export type SiteNavKey = "install" | "agents" | "blog" | "changelog";
+
 const navLinks = [
-  { href: "/install", label: "Install" },
-  { href: "/agents", label: "Agents" },
-  { href: "/changelog", label: "Changelog" },
-  { href: "/blog", label: "Blog" },
-  { href: siteConfig.links.github, label: "GitHub", external: true },
-  { href: siteConfig.links.releases, label: "Releases", external: true },
+  { key: "install", href: "/install", label: "Install" },
+  { key: "agents", href: "/agents", label: "Agents" },
+  { key: "blog", href: "/blog", label: "Blog" },
+  { key: "changelog", href: "/changelog", label: "Changelog" },
+  { key: "github", href: siteConfig.links.github, label: "GitHub", external: true },
 ] as const;
 
-function SiteNavLink({
-  href,
-  label,
-  external = false,
-  variant = "light",
-}: {
-  href: string;
-  label: string;
-  external?: boolean;
-  variant?: HeaderVariant;
-}) {
-  const isDark = variant === "dark";
-  const linkClassName = cn(
-    "text-sm font-medium transition-colors",
-    isDark
-      ? "text-white/70 hover:text-white"
-      : "text-gray-500 hover:text-gray-900"
-  );
-
-  if (external) {
-    return (
-      <a
-        href={href}
-        className={linkClassName}
-        rel="noreferrer"
-        target="_blank"
-      >
-        {label}
-      </a>
-    );
-  }
-
-  return (
-    <Link href={href} className={linkClassName}>
-      {label}
-    </Link>
-  );
-}
-
 interface SiteHeaderProps {
-  variant?: HeaderVariant;
+  /** Which nav item the current page lives under. */
+  active?: SiteNavKey;
 }
 
-export function SiteHeader({ variant = "light" }: SiteHeaderProps) {
-  const isDark = variant === "dark";
-  const isFloating = variant === "floating";
-
-  if (isFloating) {
-    return (
-      <header className="sticky top-0 z-50 px-4 pt-4 sm:pt-6">
-        <div className="mx-auto flex max-w-3xl items-center justify-between gap-4 rounded-full border border-black/5 bg-white/80 px-4 py-2.5 shadow-sm backdrop-blur-md sm:px-6">
-          <Link
-            href="/"
-            className="inline-flex items-center gap-2.5 transition-opacity hover:opacity-80"
-          >
-            <Logo className="h-7 w-7" />
-            <span className="text-sm font-semibold tracking-tight text-gray-900">
-              {siteConfig.name}
-            </span>
-          </Link>
-          <nav className="flex items-center gap-3 sm:gap-5">
-            {navLinks.map((link) => (
-              <SiteNavLink key={link.href} {...link} />
-            ))}
-          </nav>
-        </div>
-      </header>
-    );
-  }
-
+/**
+ * Mono Ledger header: mono wordmark, a hairline rule, and mono uppercase nav.
+ * The active page carries a 2px underline. Colors route through the Elements
+ * tokens, so the same header works on the light and Ink surfaces. The logo
+ * mark keeps its black strokes on both — the pastel quadrants carry the
+ * contrast, and white strokes turn to mush at 22px.
+ */
+export function SiteHeader({ active }: SiteHeaderProps) {
   return (
-    <header
-      className={cn(
-        isDark
-          ? "absolute inset-x-0 top-0 z-50 border-b border-white/10 bg-transparent"
-          : "border-b border-black/5 bg-white/90 backdrop-blur"
-      )}
-    >
-      <Container className="flex h-16 items-center justify-between gap-6">
-        <Link
-          href="/"
-          className={cn(
-            "inline-flex items-center gap-3 transition-opacity hover:opacity-80",
-            isDark ? "text-white" : "text-gray-900"
-          )}
-        >
-          <Logo className="h-9 w-9" variant={isDark ? "light" : "default"} />
-          <span className="text-base font-semibold tracking-tight">
-            {siteConfig.name}
+    <header className="border-b border-border">
+      <div className="mx-auto flex min-h-[52px] w-full max-w-5xl flex-wrap items-center gap-x-6 gap-y-1 px-5 py-2 sm:flex-nowrap sm:px-7 sm:py-0">
+        <Link href="/" className="flex shrink-0 items-center gap-[9px]">
+          <Logo className="h-[22px] w-[22px]" />
+          <span className="font-mono text-[13px] font-semibold tracking-[0.04em] text-foreground">
+            nteract
           </span>
         </Link>
+        <div className="hidden h-px flex-grow bg-border sm:block" />
+        <nav className="flex items-center gap-4 font-mono text-[11px] uppercase tracking-[0.14em] sm:gap-[22px]">
+          {navLinks.map((link) => {
+            const isActive = "key" in link && link.key === active;
+            const className = cn(
+              "transition-colors",
+              isActive
+                ? "text-foreground underline decoration-2 underline-offset-[6px]"
+                : "text-muted-foreground hover:text-foreground",
+            );
 
-        <nav className="flex items-center gap-4 sm:gap-6">
-          {navLinks.map((link) => (
-            <SiteNavLink key={link.href} {...link} variant={variant} />
-          ))}
+            if ("external" in link && link.external) {
+              return (
+                <a
+                  key={link.key}
+                  href={link.href}
+                  className={className}
+                  rel="noreferrer"
+                  target="_blank"
+                >
+                  {link.label}
+                </a>
+              );
+            }
+
+            return (
+              <Link key={link.key} href={link.href} className={className}>
+                {link.label}
+              </Link>
+            );
+          })}
         </nav>
-      </Container>
+      </div>
     </header>
   );
 }
 
 export function SiteFooter() {
   return (
-    <footer className="border-t border-black/5 bg-gray-50/80">
-      <Container className="flex flex-col gap-8 py-10 text-sm text-gray-500 sm:flex-row sm:items-end sm:justify-between">
+    <footer className="border-t border-border">
+      <Container className="flex flex-col gap-8 py-10 text-sm text-muted-foreground sm:flex-row sm:items-end sm:justify-between">
         <div className="max-w-md space-y-2">
-          <p className="italic text-gray-400">{siteConfig.quote.body}</p>
-          <p className="text-xs text-gray-400">— {siteConfig.quote.author}</p>
+          <p className="italic">{siteConfig.quote.body}</p>
+          <p className="text-xs">— {siteConfig.quote.author}</p>
         </div>
 
-        <div className="space-y-2 sm:text-right">
-          <div className="flex flex-wrap gap-4 sm:justify-end">
-            <Link href="/agents" className="transition-colors hover:text-gray-900">
+        <div className="space-y-3 sm:text-right">
+          <div className="flex flex-wrap gap-4 font-mono text-[11px] uppercase tracking-[0.14em] sm:justify-end">
+            <Link href="/agents" className="transition-colors hover:text-foreground">
               Agents
             </Link>
             <Link
               href="/changelog"
-              className="transition-colors hover:text-gray-900"
+              className="transition-colors hover:text-foreground"
             >
               Changelog
             </Link>
-            <Link href="/blog" className="transition-colors hover:text-gray-900">
+            <Link href="/blog" className="transition-colors hover:text-foreground">
               Blog
             </Link>
             <Link
               href="/telemetry"
-              className="transition-colors hover:text-gray-900"
+              className="transition-colors hover:text-foreground"
             >
               Telemetry
             </Link>
             <a
               href={siteConfig.links.rss}
-              className="transition-colors hover:text-gray-900"
+              className="transition-colors hover:text-foreground"
             >
               RSS
             </a>
             <a
               href={siteConfig.links.github}
-              className="transition-colors hover:text-gray-900"
+              className="transition-colors hover:text-foreground"
               rel="noreferrer"
               target="_blank"
             >
               GitHub
             </a>
           </div>
-          <p className="text-xs text-gray-400">
+          <p className="font-mono text-[10px] uppercase tracking-[0.14em]">
             Native interactive notebooks for humans and agents.
           </p>
         </div>

--- a/components/telemetry/page-shell.tsx
+++ b/components/telemetry/page-shell.tsx
@@ -1,10 +1,17 @@
 import type { ReactNode } from "react";
 
+import { SiteHeader } from "@/components/site-shell";
+
 export function PageShell({ children }: { children: ReactNode }) {
+  // The header sits outside .cream-page: the cream scope restyles every <a>
+  // (accent color + underline), which would repaint the site nav.
   return (
-    <div className="cream-page min-h-screen">
-      <div className="mx-auto max-w-6xl px-5 sm:px-8 lg:px-12 py-16 lg:py-24">
-        {children}
+    <div className="flex min-h-screen flex-col bg-background text-foreground">
+      <SiteHeader />
+      <div className="cream-page flex-1">
+        <div className="mx-auto max-w-6xl px-5 sm:px-8 lg:px-12 py-16 lg:py-24">
+          {children}
+        </div>
       </div>
     </div>
   );

--- a/components/ui/button-variants.ts
+++ b/components/ui/button-variants.ts
@@ -1,0 +1,30 @@
+import { cva } from "class-variance-authority"
+
+/**
+ * Elements button recipe. Lives outside the client component so server
+ * components can style plain <a>/<Link> elements as buttons via
+ * buttonVariants().
+ */
+export const buttonVariants = cva(
+  "inline-flex shrink-0 items-center justify-center gap-2 whitespace-nowrap rounded-lg text-sm font-medium outline-none transition-colors select-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-primary text-primary-foreground hover:bg-[color-mix(in_srgb,var(--primary)_88%,var(--background))]",
+        outline:
+          "border border-border bg-transparent text-foreground hover:bg-muted",
+        ghost: "text-foreground hover:bg-muted",
+      },
+      size: {
+        default: "h-9 px-4",
+        sm: "h-8 px-3.5 text-[0.8rem]",
+        lg: "h-10 px-5",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,46 +1,10 @@
 "use client"
 
 import { Button as ButtonPrimitive } from "@base-ui/react/button"
-import { cva, type VariantProps } from "class-variance-authority"
+import type { VariantProps } from "class-variance-authority"
 
+import { buttonVariants } from "@/components/ui/button-variants"
 import { cn } from "@/lib/utils"
-
-const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-oklch(0.922 0 0) border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-oklch(0.708 0 0) focus-visible:ring-3 focus-visible:ring-oklch(0.708 0 0)/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-oklch(0.577 0.245 27.325) aria-invalid:ring-3 aria-invalid:ring-oklch(0.577 0.245 27.325)/20 dark:aria-invalid:border-oklch(0.577 0.245 27.325)/50 dark:aria-invalid:ring-oklch(0.577 0.245 27.325)/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 dark:border-oklch(1 0 0 / 10%) dark:focus-visible:border-oklch(0.556 0 0) dark:focus-visible:ring-oklch(0.556 0 0)/50 dark:aria-invalid:border-oklch(0.704 0.191 22.216) dark:aria-invalid:ring-oklch(0.704 0.191 22.216)/20 dark:dark:aria-invalid:border-oklch(0.704 0.191 22.216)/50 dark:dark:aria-invalid:ring-oklch(0.704 0.191 22.216)/40",
-  {
-    variants: {
-      variant: {
-        default: "bg-oklch(0.205 0 0) text-oklch(0.985 0 0) [a]:hover:bg-oklch(0.205 0 0)/80 dark:bg-oklch(0.922 0 0) dark:text-oklch(0.205 0 0) dark:[a]:hover:bg-oklch(0.922 0 0)/80",
-        outline:
-          "border-oklch(0.922 0 0) bg-oklch(1 0 0) hover:bg-oklch(0.97 0 0) hover:text-oklch(0.145 0 0) aria-expanded:bg-oklch(0.97 0 0) aria-expanded:text-oklch(0.145 0 0) dark:border-oklch(0.922 0 0) dark:bg-oklch(0.922 0 0)/30 dark:hover:bg-oklch(0.922 0 0)/50 dark:border-oklch(1 0 0 / 10%) dark:bg-oklch(0.145 0 0) dark:hover:bg-oklch(0.269 0 0) dark:hover:text-oklch(0.985 0 0) dark:aria-expanded:bg-oklch(0.269 0 0) dark:aria-expanded:text-oklch(0.985 0 0) dark:dark:border-oklch(1 0 0 / 15%) dark:dark:bg-oklch(1 0 0 / 15%)/30 dark:dark:hover:bg-oklch(1 0 0 / 15%)/50",
-        secondary:
-          "bg-oklch(0.97 0 0) text-oklch(0.205 0 0) hover:bg-oklch(0.97 0 0)/80 aria-expanded:bg-oklch(0.97 0 0) aria-expanded:text-oklch(0.205 0 0) dark:bg-oklch(0.269 0 0) dark:text-oklch(0.985 0 0) dark:hover:bg-oklch(0.269 0 0)/80 dark:aria-expanded:bg-oklch(0.269 0 0) dark:aria-expanded:text-oklch(0.985 0 0)",
-        ghost:
-          "hover:bg-oklch(0.97 0 0) hover:text-oklch(0.145 0 0) aria-expanded:bg-oklch(0.97 0 0) aria-expanded:text-oklch(0.145 0 0) dark:hover:bg-oklch(0.97 0 0)/50 dark:hover:bg-oklch(0.269 0 0) dark:hover:text-oklch(0.985 0 0) dark:aria-expanded:bg-oklch(0.269 0 0) dark:aria-expanded:text-oklch(0.985 0 0) dark:dark:hover:bg-oklch(0.269 0 0)/50",
-        destructive:
-          "bg-oklch(0.577 0.245 27.325)/10 text-oklch(0.577 0.245 27.325) hover:bg-oklch(0.577 0.245 27.325)/20 focus-visible:border-oklch(0.577 0.245 27.325)/40 focus-visible:ring-oklch(0.577 0.245 27.325)/20 dark:bg-oklch(0.577 0.245 27.325)/20 dark:hover:bg-oklch(0.577 0.245 27.325)/30 dark:focus-visible:ring-oklch(0.577 0.245 27.325)/40 dark:bg-oklch(0.704 0.191 22.216)/10 dark:text-oklch(0.704 0.191 22.216) dark:hover:bg-oklch(0.704 0.191 22.216)/20 dark:focus-visible:border-oklch(0.704 0.191 22.216)/40 dark:focus-visible:ring-oklch(0.704 0.191 22.216)/20 dark:dark:bg-oklch(0.704 0.191 22.216)/20 dark:dark:hover:bg-oklch(0.704 0.191 22.216)/30 dark:dark:focus-visible:ring-oklch(0.704 0.191 22.216)/40",
-        link: "text-oklch(0.205 0 0) underline-offset-4 hover:underline dark:text-oklch(0.922 0 0)",
-      },
-      size: {
-        default:
-          "h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
-        xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
-        sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
-        lg: "h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3",
-        icon: "size-8",
-        "icon-xs":
-          "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",
-        "icon-sm":
-          "size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg",
-        "icon-lg": "size-9",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-      size: "default",
-    },
-  }
-)
 
 function Button({
   className,

--- a/lib/blog.ts
+++ b/lib/blog.ts
@@ -18,8 +18,18 @@ export type BlogPostFrontmatter = {
   authors: BlogAuthor[];
 };
 
+export type NotebookComposition = {
+  code: number;
+  markdown: number;
+  raw: number;
+};
+
 export type BlogPostSummary = BlogPostFrontmatter & {
   slug: string;
+  /** Cell-type fingerprint of the post body: fenced code blocks count as
+      code cells, prose blocks as markdown cells. Feeds the composition
+      ticks on post cards. */
+  composition: NotebookComposition;
 };
 
 export type BlogPost = BlogPostSummary & {
@@ -134,6 +144,17 @@ function toSlug(fileName: string) {
   return fileName.replace(/\.mdx?$/, "");
 }
 
+function computeComposition(content: string): NotebookComposition {
+  const fences = content.match(/^\s*```/gm) ?? [];
+  const code = Math.floor(fences.length / 2);
+  const prose = content
+    .replace(/^\s*```[\s\S]*?^\s*```/gm, "")
+    .split(/\n{2,}/)
+    .filter((block) => block.trim().length > 0).length;
+
+  return { code, markdown: prose, raw: 0 };
+}
+
 function compareByDateDescending(
   left: BlogPostSummary,
   right: BlogPostSummary,
@@ -163,6 +184,7 @@ function readAllPostsFromDisk(): Promise<BlogPost[]> {
         return {
           slug: toSlug(fileName),
           content,
+          composition: computeComposition(content),
           ...frontmatter,
         } satisfies BlogPost;
       }),

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,7 +10,25 @@ module.exports = {
     extend: {
       colors: {
         accent: "rgb(var(--accent) / <alpha-value>)",
-        // Monolith design system
+        // nteract Elements semantic tokens (light/.dark via CSS vars)
+        background: "var(--background)",
+        foreground: "var(--foreground)",
+        card: {
+          DEFAULT: "var(--card)",
+          foreground: "var(--card-foreground)",
+        },
+        primary: {
+          DEFAULT: "var(--primary)",
+          foreground: "var(--primary-foreground)",
+        },
+        muted: {
+          DEFAULT: "var(--muted)",
+          foreground: "var(--muted-foreground)",
+        },
+        border: "var(--border)",
+        ring: "var(--ring)",
+        // Monolith grayscale, still consumed by the blog's dark diagram
+        // islands (socket-diagram, peekaboo, env-picker) and the OG images.
         surface: {
           DEFAULT: "#0e0e0e",
           dim: "#0e0e0e",
@@ -28,23 +46,10 @@ module.exports = {
           DEFAULT: "#e5e5e5",
           variant: "#ababab",
         },
-        primary: {
-          DEFAULT: "#94ccff",
-          dim: "#73bfff",
-          container: "#004b74",
-        },
-        "on-primary": {
-          DEFAULT: "#00446a",
-          container: "#a9d5ff",
-        },
         secondary: {
           DEFAULT: "#a993d1",
           dim: "#a993d1",
           container: "#443167",
-        },
-        "on-secondary": {
-          DEFAULT: "#28144a",
-          container: "#cbb5f4",
         },
         tertiary: {
           DEFAULT: "#8ef4e9",
@@ -63,6 +68,10 @@ module.exports = {
       },
       borderRadius: {
         none: "0px",
+        sm: "calc(var(--radius) - 4px)",
+        md: "calc(var(--radius) - 2px)",
+        lg: "var(--radius)",
+        xl: "calc(var(--radius) + 4px)",
       },
     },
   },


### PR DESCRIPTION
Three visual systems had drifted apart: the dark "Monolith" blog (Space Grotesk, purple/teal), the cream serif changelog, and gray product pages with teal accents. Each page looked like it shipped from a different team. This moves everything onto one token system, per the "Unified Site Directions" doc worked out over four rounds in the "Unifying nteract components" design project.

## Tokens

`app/globals.css` now carries the nteract Elements tokens: neutral oklch grayscale in `:root` and a `.dark` wrapper class, radius `0.625rem`, and chromatic color reserved for meaning rather than decoration (`--ct-*` cell types, `--k-*` runtime state, ported from the app's `dashboard-atoms.css`). Body font moves to Geist; Space Grotesk headings are gone from prose. The old Monolith palette stays in `tailwind.config.js` but only for the blog's dark diagram islands (socket-diagram, env-picker, peekaboo) and OG image generation, since those are illustration, not chrome.

## Header and nav

`components/site-shell.tsx` gets one header everywhere: 52px, mono wordmark, hairline rule, mono uppercase nav, 2px underline on the active page. Nav is down to Install / Agents / Blog / Changelog / GitHub. Releases dropped since it's reachable through GitHub and the changelog already covers it. The logo keeps black strokes even on dark surfaces. The white-stroke variant turns to mush at 22px, so it wasn't worth keeping around as a variant.

## Agents page

`/agents` is rebuilt on design option 4a, "Agents: Show Your Work," on the Ink dark surface. Five step cards and a teal callout collapse into one spread: two side-by-side install cards (Claude Code / Codex), a "what agents get" list, and a single CTA.

## Blog

The blog stays on the Ink dark surface: its graphics (cover videos, diagram islands) are composed against the dark palette. It picks up mono ledger meta rows, a 44px hero title, muted tag chips, and a framed cover video. Older-post cards show `NotebookCompositionTicks`, driven by real data: each post's code/markdown balance is computed from its MDX in `lib/blog.ts`, not decorative. Post prose is rebuilt on tokens: drop cap and purple links are gone, code blocks are bordered cards with mono title rows, and shiki's dual themes key off surface instead of `prose-invert`.

## Changelog

Light surface, 140px left rail with mono version, `RuntimeStatusDot`, and date. The dot reflects real release state: green "shipped" for published entries, amber "in progress" for drafts. The page shell moved out of the route-group layout and into the index and `[version]` pages directly, so `/changelog/print` keeps its own ink-on-paper treatment.

The index also stops inlining every release's full MDX body. It was compiling seven MDX bodies per request (the page is `force-dynamic` for the draft gate, so nothing caches) and shipping ~940KB of HTML. The feed now carries title, summary, highlights, hero, and tags; the narrative and the technical changelog render on demand on the per-version page. Index HTML drops to ~114KB.

## Home, install, telemetry

Home and install are restyled onto tokens; install picks up the ledger layout. Telemetry keeps its cream body under the new header. The header lives outside `.cream-page` on purpose. That scope restyles every `<a>`, and the header's own links need to stay on the token system.

## New components

`components/elements/` gets `RuntimeStatusDot` and `NotebookCompositionTicks`, ported from the app repo. `components/ui/button.tsx` is rewritten on semantic tokens, with the `cva` recipe split into `button-variants.ts` so server components can style links as buttons without pulling in client-only code.

## Verified

65 vitest tests pass, `next build` passes, every page checked visually in Chrome: `/`, `/agents`, `/blog`, `/blog/security`, `/changelog`, `/changelog/print`, `/install`, `/telemetry`.
