### PR TITLE
Render changelog release bodies on demand

### DIFF
--- a/app/(changelog)/changelog/page.tsx
+++ b/app/(changelog)/changelog/page.tsx
@@ -52,15 +52,6 @@ export default async function ChangelogPage() {
     includeUnpublished: shouldShowDrafts(host),
   });
 
-  const rendered = await Promise.all(
-    entries.map(async (entry) => {
-      const { default: Content } = await import(
-        `@/content/changelog/${entry.version}.mdx`
-      );
-      return { entry, Content };
-    }),
-  );
-
   return (
     <div className="flex min-h-screen flex-col bg-background text-foreground">
       <SiteHeader active="changelog" />
@@ -90,12 +81,10 @@ export default async function ChangelogPage() {
           {description}
         </p>
 
-        {rendered.length > 0 ? (
+        {entries.length > 0 ? (
           <div>
-            {rendered.map(({ entry, Content }) => (
-              <ChangelogFeedEntry key={entry.version} entry={entry}>
-                <Content />
-              </ChangelogFeedEntry>
+            {entries.map((entry) => (
+              <ChangelogFeedEntry key={entry.version} entry={entry} />
             ))}
           </div>
         ) : (

--- a/components/changelog/changelog-feed-entry.tsx
+++ b/components/changelog/changelog-feed-entry.tsx
@@ -1,26 +1,21 @@
-import type { ReactNode } from "react";
-
 import Link from "next/link";
 
 import { ChangelogTagList } from "@/components/changelog/tag-list";
 import { RuntimeStatusDot } from "@/components/elements/runtime-status-dot";
-import { Prose } from "@/components/prose";
 import { formatEntryDate, type ChangelogEntrySummary } from "@/lib/changelog";
 
 type ChangelogFeedEntryProps = {
   entry: ChangelogEntrySummary;
-  /** The entry's MDX body, rendered inline in the feed. */
-  children?: ReactNode;
 };
 
 /**
- * One release rendered in full inline in the scrolling feed: version, shipped
- * state, and date in a left rail, the whole story on the right (highlights,
- * hero, and the MDX body, whose exhaustive technical changelog stays inside
- * its collapsed disclosure). The version and title link to the shareable
- * per-version page.
+ * One release in the scrolling feed: version, shipped state, and date in a
+ * left rail; title, summary, highlights, and hero on the right. The narrative
+ * body and the exhaustive technical changelog stay on the per-version page,
+ * which the version, title, and release-notes link all point at — keeping the
+ * index payload small.
  */
-export function ChangelogFeedEntry({ entry, children }: ChangelogFeedEntryProps) {
+export function ChangelogFeedEntry({ entry }: ChangelogFeedEntryProps) {
   const href = `/changelog/${entry.version}`;
 
   return (
@@ -97,16 +92,13 @@ export function ChangelogFeedEntry({ entry, children }: ChangelogFeedEntryProps)
           </div>
         ) : null}
 
-        {/* Full body, rendered inline */}
-        {children ? <Prose className="mt-2">{children}</Prose> : null}
-
         <div className="mt-3 flex flex-wrap items-center gap-5">
           <ChangelogTagList tags={entry.tags} />
           <Link
             href={href}
             className="font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground transition-colors hover:text-foreground"
           >
-            Permalink →
+            Release notes →
           </Link>
         </div>
       </div>


### PR DESCRIPTION
The changelog index rendered every release's full MDX body inline, including the collapsed "full technical changelog" sections. The page is `force-dynamic` for the draft gate (it reads the request host, since `VERCEL_ENV` isn't exposed to app code here), so every visit compiled seven MDX bodies server-side and shipped ~940KB of HTML that `no-store` made uncacheable.

The feed now carries what the redesign showed anyway: version rail, title, summary, highlights, hero, and tags. The narrative body and the technical changelog render on demand on the per-version page, which the version, title, and the "Release notes →" link (formerly "Permalink →") all point at. Index HTML drops to ~114KB and the per-request MDX compilation goes away.

`/changelog/[version]` and `/changelog/print` are unchanged; print still renders everything since printing everything is its job.

Follow-up to #654.
