### PR TITLE
Unify the changelog header hierarchy

### DIFF
--- a/app/(changelog)/changelog/[version]/page.tsx
+++ b/app/(changelog)/changelog/[version]/page.tsx
@@ -3,6 +3,7 @@ import { headers } from "next/headers";
 import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
 
+import { ChangelogGrid, ChangelogMain } from "@/components/changelog/layout";
 import { ChangelogTagList } from "@/components/changelog/tag-list";
 import { Prose } from "@/components/prose";
 import { SiteFooter, SiteHeader } from "@/components/site-shell";
@@ -96,40 +97,46 @@ export default async function ChangelogVersionPage({
     <div className="flex min-h-screen flex-col bg-background text-foreground">
       <SiteHeader active="changelog" />
 
-      <main className="mx-auto w-full max-w-[45rem] flex-1 px-6 pb-[72px] pt-16 sm:px-10">
+      <ChangelogMain>
         <article>
           {/* Header */}
           <header className="mb-10">
-            <div className="mb-7 flex items-center gap-3 font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
+            <ChangelogGrid className="mb-7 flex items-center gap-3 font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
               <Link
                 href="/changelog"
                 className="text-foreground transition-colors hover:text-muted-foreground"
               >
                 ← Changelog
               </Link>
-              <div className="h-px flex-grow bg-border" />
-              <time dateTime={entry.date}>{formatEntryDate(entry)}</time>
-            </div>
+              <div className="flex flex-1 items-center gap-3">
+                <div className="h-px flex-grow bg-border" />
+                <time dateTime={entry.date}>{formatEntryDate(entry)}</time>
+              </div>
+            </ChangelogGrid>
 
-            <div className="mb-4 font-mono text-[32px] font-semibold tracking-[-0.02em] text-foreground">
-              {entry.version}
-            </div>
+            <ChangelogGrid>
+              <div className="mb-5 font-mono text-[32px] font-semibold tracking-[-0.02em] text-foreground md:mb-0">
+                {entry.version}
+              </div>
 
-            <h1 className="mb-3 text-[32px] font-bold leading-[1.05] tracking-[-0.03em] text-foreground sm:text-[40px]">
-              {entry.title}
-            </h1>
+              <div>
+                <h1 className="mb-3 text-[32px] font-bold leading-[1.05] tracking-[-0.03em] text-foreground sm:text-[40px]">
+                  {entry.title}
+                </h1>
 
-            <p className="mb-6 max-w-[560px] text-lg leading-normal text-muted-foreground">
-              {entry.summary}
-            </p>
+                <p className="mb-6 max-w-[42rem] text-lg leading-normal text-muted-foreground">
+                  {entry.summary}
+                </p>
 
-            <ChangelogTagList tags={entry.tags} />
+                <ChangelogTagList tags={entry.tags} />
+              </div>
+            </ChangelogGrid>
           </header>
 
           {/* Hero */}
           {entry.heroVideo ? (
-            <section className="mb-12">
-              <div className="overflow-hidden rounded-lg border border-border">
+            <ChangelogGrid as="section" className="mb-12">
+              <div className="overflow-hidden rounded-lg border border-border md:col-start-2">
                 <video
                   src={entry.heroVideo}
                   poster={entry.heroVideoPoster}
@@ -140,69 +147,75 @@ export default async function ChangelogVersionPage({
                   className="block w-full"
                 />
               </div>
-            </section>
+            </ChangelogGrid>
           ) : entry.heroImage ? (
-            <section className="mb-12">
-              <div className="aspect-video w-full overflow-hidden rounded-lg border border-border bg-card">
+            <ChangelogGrid as="section" className="mb-12">
+              <div className="aspect-video w-full overflow-hidden rounded-lg border border-border bg-card md:col-start-2">
                 <img
                   alt={entry.title}
                   className="h-full w-full object-cover"
                   src={entry.heroImage}
                 />
               </div>
-            </section>
+            </ChangelogGrid>
           ) : null}
 
           {/* Highlights */}
           {entry.highlights.length > 0 ? (
-            <section className="mb-12">
-              <h2 className="mb-4 text-2xl font-bold tracking-[-0.02em]">
-                Highlights
-              </h2>
-              <ul className="flex flex-col gap-2.5">
-                {entry.highlights.map((highlight) => (
-                  <li
-                    key={highlight}
-                    className="flex gap-2.5 text-[15.5px] leading-normal"
-                  >
-                    <span
-                      aria-hidden="true"
-                      className="mt-2 h-[5px] w-[5px] shrink-0 rounded-[1px] bg-foreground"
-                    />
-                    <span>{highlight}</span>
-                  </li>
-                ))}
-              </ul>
-            </section>
+            <ChangelogGrid as="section" className="mb-12">
+              <div className="max-w-[42rem] md:col-start-2">
+                <h2 className="mb-4 text-2xl font-bold tracking-[-0.02em]">
+                  Highlights
+                </h2>
+                <ul className="flex flex-col gap-2.5">
+                  {entry.highlights.map((highlight) => (
+                    <li
+                      key={highlight}
+                      className="flex gap-2.5 text-[15.5px] leading-normal"
+                    >
+                      <span
+                        aria-hidden="true"
+                        className="mt-2 h-[5px] w-[5px] shrink-0 rounded-[1px] bg-foreground"
+                      />
+                      <span>{highlight}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </ChangelogGrid>
           ) : null}
 
           {/* Body — narrative + full technical changelog */}
-          <Prose>
-            <Content />
-          </Prose>
+          <ChangelogGrid>
+            <Prose className="max-w-[42rem] md:col-start-2">
+              <Content />
+            </Prose>
+          </ChangelogGrid>
 
           {/* Footer */}
-          <div className="mt-14 flex flex-wrap items-center gap-3 font-mono text-[11px] uppercase tracking-[0.14em]">
-            <Link
-              href="/changelog"
-              className="text-foreground transition-colors hover:text-muted-foreground"
-            >
-              ← All releases
-            </Link>
-            <div className="h-px flex-grow bg-border" />
-            {entry.githubReleaseUrl ? (
-              <a
-                href={entry.githubReleaseUrl}
-                className="text-muted-foreground transition-colors hover:text-foreground"
-                rel="noreferrer"
-                target="_blank"
+          <ChangelogGrid>
+            <div className="mt-14 flex flex-wrap items-center gap-3 font-mono text-[11px] uppercase tracking-[0.14em] md:col-start-2">
+              <Link
+                href="/changelog"
+                className="text-foreground transition-colors hover:text-muted-foreground"
               >
-                GitHub release →
-              </a>
-            ) : null}
-          </div>
+                ← All releases
+              </Link>
+              <div className="h-px flex-grow bg-border" />
+              {entry.githubReleaseUrl ? (
+                <a
+                  href={entry.githubReleaseUrl}
+                  className="text-muted-foreground transition-colors hover:text-foreground"
+                  rel="noreferrer"
+                  target="_blank"
+                >
+                  GitHub release →
+                </a>
+              ) : null}
+            </div>
+          </ChangelogGrid>
         </article>
-      </main>
+      </ChangelogMain>
 
       <SiteFooter />
     </div>

--- a/app/(changelog)/changelog/page.tsx
+++ b/app/(changelog)/changelog/page.tsx
@@ -3,6 +3,7 @@ import { headers } from "next/headers";
 import Link from "next/link";
 
 import { ChangelogFeedEntry } from "@/components/changelog/changelog-feed-entry";
+import { ChangelogGrid, ChangelogMain } from "@/components/changelog/layout";
 import { SiteFooter, SiteHeader } from "@/components/site-shell";
 import { getAllEntries, shouldShowDrafts } from "@/lib/changelog";
 import { absoluteUrl, siteConfig } from "@/lib/site";
@@ -56,9 +57,9 @@ export default async function ChangelogPage() {
     <div className="flex min-h-screen flex-col bg-background text-foreground">
       <SiteHeader active="changelog" />
 
-      <main className="mx-auto w-full max-w-5xl flex-1 px-5 pb-[72px] pt-16 sm:px-7">
+      <ChangelogMain>
         <header className="mb-11">
-          <div className="mb-7 flex items-center gap-3 font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground md:grid md:grid-cols-[140px_1fr] md:gap-7">
+          <ChangelogGrid className="mb-7 flex items-center gap-3 font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
             <span>Changelog</span>
             <div className="flex flex-1 items-center gap-3">
               <div className="h-px flex-grow bg-border" />
@@ -75,9 +76,9 @@ export default async function ChangelogPage() {
                 RSS
               </a>
             </div>
-          </div>
+          </ChangelogGrid>
 
-          <div className="md:grid md:grid-cols-[140px_1fr] md:gap-7">
+          <ChangelogGrid>
             <div className="md:col-start-2">
               <h1 className="mb-3 text-[40px] font-extrabold leading-[0.98] tracking-[-0.04em] sm:text-[56px]">
                 Changelog
@@ -86,7 +87,7 @@ export default async function ChangelogPage() {
                 {description}
               </p>
             </div>
-          </div>
+          </ChangelogGrid>
         </header>
 
         {entries.length > 0 ? (
@@ -100,7 +101,7 @@ export default async function ChangelogPage() {
             The first release notes are still in draft. Check back soon.
           </div>
         )}
-      </main>
+      </ChangelogMain>
 
       <SiteFooter />
     </div>

--- a/app/(changelog)/changelog/page.tsx
+++ b/app/(changelog)/changelog/page.tsx
@@ -56,30 +56,38 @@ export default async function ChangelogPage() {
     <div className="flex min-h-screen flex-col bg-background text-foreground">
       <SiteHeader active="changelog" />
 
-      <main className="mx-auto w-full max-w-[45rem] flex-1 px-6 pb-[72px] pt-16 sm:px-10">
-        <div className="mb-7 flex items-center gap-3 font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
-          <span>Changelog</span>
-          <div className="h-px flex-grow bg-border" />
-          <Link
-            href="/changelog/print"
-            className="transition-colors hover:text-foreground"
-          >
-            Print
-          </Link>
-          <a
-            href="/changelog/feed.xml"
-            className="transition-colors hover:text-foreground"
-          >
-            RSS
-          </a>
-        </div>
+      <main className="mx-auto w-full max-w-5xl flex-1 px-5 pb-[72px] pt-16 sm:px-7">
+        <header className="mb-11">
+          <div className="mb-7 flex items-center gap-3 font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground md:grid md:grid-cols-[140px_1fr] md:gap-7">
+            <span>Changelog</span>
+            <div className="flex flex-1 items-center gap-3">
+              <div className="h-px flex-grow bg-border" />
+              <Link
+                href="/changelog/print"
+                className="transition-colors hover:text-foreground"
+              >
+                Print
+              </Link>
+              <a
+                href="/changelog/feed.xml"
+                className="transition-colors hover:text-foreground"
+              >
+                RSS
+              </a>
+            </div>
+          </div>
 
-        <h1 className="mb-3 text-[40px] font-extrabold leading-[0.98] tracking-[-0.04em] sm:text-[56px]">
-          Changelog
-        </h1>
-        <p className="mb-11 max-w-[560px] text-[17px] leading-[1.55] text-muted-foreground">
-          {description}
-        </p>
+          <div className="md:grid md:grid-cols-[140px_1fr] md:gap-7">
+            <div className="md:col-start-2">
+              <h1 className="mb-3 text-[40px] font-extrabold leading-[0.98] tracking-[-0.04em] sm:text-[56px]">
+                Changelog
+              </h1>
+              <p className="max-w-[42rem] text-[17px] leading-[1.55] text-muted-foreground">
+                {description}
+              </p>
+            </div>
+          </div>
+        </header>
 
         {entries.length > 0 ? (
           <div>

--- a/components/changelog/changelog-feed-entry.tsx
+++ b/components/changelog/changelog-feed-entry.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 
+import { ChangelogGrid } from "@/components/changelog/layout";
 import { ChangelogTagList } from "@/components/changelog/tag-list";
 import { formatEntryDate, type ChangelogEntrySummary } from "@/lib/changelog";
 
@@ -18,9 +19,10 @@ export function ChangelogFeedEntry({ entry }: ChangelogFeedEntryProps) {
   const href = `/changelog/${entry.version}`;
 
   return (
-    <article
+    <ChangelogGrid
+      as="article"
       id={`v${entry.version}`}
-      className="scroll-mt-24 border-t border-border py-9 md:grid md:grid-cols-[140px_1fr] md:gap-7"
+      className="scroll-mt-24 border-t border-border py-9"
     >
       {/* Left rail — version + date */}
       <div className="mb-5 flex flex-row items-baseline gap-4 md:mb-0 md:flex-col md:items-start md:gap-2">
@@ -50,23 +52,6 @@ export function ChangelogFeedEntry({ entry }: ChangelogFeedEntryProps) {
           {entry.summary}
         </p>
 
-        {entry.highlights.length > 0 ? (
-          <ul className="mt-1 flex max-w-[42rem] flex-col gap-[7px]">
-            {entry.highlights.map((highlight) => (
-              <li
-                key={highlight}
-                className="flex gap-2.5 text-[14.5px] leading-[1.45] text-foreground"
-              >
-                <span
-                  aria-hidden="true"
-                  className="mt-[7px] h-[5px] w-[5px] shrink-0 rounded-[1px] bg-foreground"
-                />
-                <span>{highlight}</span>
-              </li>
-            ))}
-          </ul>
-        ) : null}
-
         {/* Hero — driven by heroVideo / heroImage frontmatter */}
         {entry.heroVideo ? (
           <div className="mt-2 overflow-hidden rounded-lg border border-border">
@@ -86,6 +71,23 @@ export function ChangelogFeedEntry({ entry }: ChangelogFeedEntryProps) {
           </div>
         ) : null}
 
+        {entry.highlights.length > 0 ? (
+          <ul className="mt-1 flex max-w-[42rem] flex-col gap-[7px]">
+            {entry.highlights.map((highlight) => (
+              <li
+                key={highlight}
+                className="flex gap-2.5 text-[14.5px] leading-[1.45] text-foreground"
+              >
+                <span
+                  aria-hidden="true"
+                  className="mt-[7px] h-[5px] w-[5px] shrink-0 rounded-[1px] bg-foreground"
+                />
+                <span>{highlight}</span>
+              </li>
+            ))}
+          </ul>
+        ) : null}
+
         <div className="mt-3 flex flex-wrap items-center gap-5">
           <ChangelogTagList tags={entry.tags} />
           <Link
@@ -96,6 +98,6 @@ export function ChangelogFeedEntry({ entry }: ChangelogFeedEntryProps) {
           </Link>
         </div>
       </div>
-    </article>
+    </ChangelogGrid>
   );
 }

--- a/components/changelog/changelog-feed-entry.tsx
+++ b/components/changelog/changelog-feed-entry.tsx
@@ -46,12 +46,12 @@ export function ChangelogFeedEntry({ entry }: ChangelogFeedEntryProps) {
           </h2>
         </Link>
 
-        <p className="text-[15px] leading-[1.55] text-muted-foreground">
+        <p className="max-w-[42rem] text-[15px] leading-[1.55] text-muted-foreground">
           {entry.summary}
         </p>
 
         {entry.highlights.length > 0 ? (
-          <ul className="mt-1 flex flex-col gap-[7px]">
+          <ul className="mt-1 flex max-w-[42rem] flex-col gap-[7px]">
             {entry.highlights.map((highlight) => (
               <li
                 key={highlight}

--- a/components/changelog/layout.tsx
+++ b/components/changelog/layout.tsx
@@ -1,0 +1,37 @@
+import type { HTMLAttributes } from "react";
+
+import { cn } from "@/lib/utils";
+
+type ChangelogMainProps = HTMLAttributes<HTMLElement>;
+
+export function ChangelogMain({ className, ...props }: ChangelogMainProps) {
+  return (
+    <main
+      className={cn(
+        "mx-auto w-full max-w-5xl flex-1 px-5 pb-[72px] pt-16 sm:px-7",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+type ChangelogGridProps = HTMLAttributes<HTMLElement> & {
+  as?: "article" | "div" | "header" | "section";
+};
+
+export function ChangelogGrid({
+  as: Component = "div",
+  className,
+  ...props
+}: ChangelogGridProps) {
+  return (
+    <Component
+      className={cn(
+        "md:grid md:grid-cols-[140px_1fr] md:gap-7",
+        className,
+      )}
+      {...props}
+    />
+  );
+}


### PR DESCRIPTION
## Summary

- widen the changelog index to the same 5xl measure as the site header
- align the changelog eyebrow with the release rail
- align the title and tagline with release titles
- use the same shared container and rail grid on individual release pages
- place index hero media directly below each release description
- keep summaries and highlights at a readable 42rem measure while allowing media to use the wider column

## Verification

- `pnpm test`
- `pnpm build`
- `git diff --check`
- visually checked the index and individual 2.6/2.7 pages at desktop width
